### PR TITLE
Feat/지수 차트 조회

### DIFF
--- a/src/main/java/com/kueennevercry/findex/config/Config.java
+++ b/src/main/java/com/kueennevercry/findex/config/Config.java
@@ -1,5 +1,0 @@
-package com.kueennevercry.findex.config;
-
-public class Config {
-
-}

--- a/src/main/java/com/kueennevercry/findex/config/OpenApiProperties.java
+++ b/src/main/java/com/kueennevercry/findex/config/OpenApiProperties.java
@@ -1,0 +1,17 @@
+package com.kueennevercry.findex.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Setter
+@Getter
+@Configuration
+@ConfigurationProperties(prefix = "openapi")
+public class OpenApiProperties {
+
+  private String baseUrl;
+  private String apiKey;
+}
+

--- a/src/main/java/com/kueennevercry/findex/config/ReseTemplateConfig.java
+++ b/src/main/java/com/kueennevercry/findex/config/ReseTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.kueennevercry.findex.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class ReseTemplateConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/com/kueennevercry/findex/controller/Contoller.java
+++ b/src/main/java/com/kueennevercry/findex/controller/Contoller.java
@@ -1,5 +1,0 @@
-package com.kueennevercry.findex.controller;
-
-public class Contoller {
-
-}

--- a/src/main/java/com/kueennevercry/findex/controller/IndexDataController.java
+++ b/src/main/java/com/kueennevercry/findex/controller/IndexDataController.java
@@ -1,0 +1,32 @@
+package com.kueennevercry.findex.controller;
+
+import com.kueennevercry.findex.dto.PeriodType;
+import com.kueennevercry.findex.dto.response.IndexChartResponse;
+import com.kueennevercry.findex.service.IndexDataService;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/index-data")
+@RequiredArgsConstructor
+public class IndexDataController {
+
+  private final IndexDataService indexDataService;
+
+  @GetMapping("/{id}/chart")
+  public ResponseEntity<IndexChartResponse> getChart(
+      @PathVariable Long id,
+      @RequestParam PeriodType periodType
+  ) throws IOException, URISyntaxException {
+    IndexChartResponse response = indexDataService.getChart(id, periodType);
+    return ResponseEntity.ok(response);
+  }
+}
+

--- a/src/main/java/com/kueennevercry/findex/dto/ChartPoint.java
+++ b/src/main/java/com/kueennevercry/findex/dto/ChartPoint.java
@@ -1,0 +1,12 @@
+package com.kueennevercry.findex.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record ChartPoint(
+    LocalDate date,
+    BigDecimal value
+) {
+
+}
+

--- a/src/main/java/com/kueennevercry/findex/dto/Dto.java
+++ b/src/main/java/com/kueennevercry/findex/dto/Dto.java
@@ -1,5 +1,0 @@
-package com.kueennevercry.findex.dto;
-
-public class Dto {
-
-}

--- a/src/main/java/com/kueennevercry/findex/dto/PeriodType.java
+++ b/src/main/java/com/kueennevercry/findex/dto/PeriodType.java
@@ -1,0 +1,5 @@
+package com.kueennevercry.findex.dto;
+
+public enum PeriodType {
+  DAILY, MONTHLY, QUARTERLY, YEARLY
+}

--- a/src/main/java/com/kueennevercry/findex/dto/request/IndexDataSyncRequest.java
+++ b/src/main/java/com/kueennevercry/findex/dto/request/IndexDataSyncRequest.java
@@ -1,0 +1,11 @@
+package com.kueennevercry.findex.dto.request;
+
+import java.time.LocalDate;
+
+public record IndexDataSyncRequest(
+    Long indexInfoId,
+    LocalDate startDate,
+    LocalDate endDate
+) {
+
+}

--- a/src/main/java/com/kueennevercry/findex/dto/response/IndexChartResponse.java
+++ b/src/main/java/com/kueennevercry/findex/dto/response/IndexChartResponse.java
@@ -1,0 +1,17 @@
+package com.kueennevercry.findex.dto.response;
+
+import com.kueennevercry.findex.dto.ChartPoint;
+import com.kueennevercry.findex.dto.PeriodType;
+import java.util.List;
+
+public record IndexChartResponse(
+    Long indexInfoId,
+    String indexClassification,
+    String indexName,
+    PeriodType periodType,
+    List<ChartPoint> dataPoints,
+    List<ChartPoint> ma5DataPoints,
+    List<ChartPoint> ma20DataPoints
+) {
+
+}

--- a/src/main/java/com/kueennevercry/findex/dto/response/IndexDataResponse.java
+++ b/src/main/java/com/kueennevercry/findex/dto/response/IndexDataResponse.java
@@ -1,0 +1,17 @@
+package com.kueennevercry.findex.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record IndexDataResponse(
+    @JsonFormat(pattern = "yyyyMMdd")
+    @JsonProperty("basDt")
+    LocalDate baseDate,
+    
+    @JsonProperty("clpr")
+    BigDecimal closingPrice
+) {
+
+}

--- a/src/main/java/com/kueennevercry/findex/entity/Entity.java
+++ b/src/main/java/com/kueennevercry/findex/entity/Entity.java
@@ -1,5 +1,0 @@
-package com.kueennevercry.findex.entity;
-
-public class Entity {
-
-}

--- a/src/main/java/com/kueennevercry/findex/entity/IndexData.java
+++ b/src/main/java/com/kueennevercry/findex/entity/IndexData.java
@@ -1,0 +1,15 @@
+package com.kueennevercry.findex.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "index_data")
+public class IndexData {
+
+  @Id
+  @GeneratedValue
+  private Long id;
+}

--- a/src/main/java/com/kueennevercry/findex/infra/openapi/DefaultOpenApiClient.java
+++ b/src/main/java/com/kueennevercry/findex/infra/openapi/DefaultOpenApiClient.java
@@ -1,0 +1,58 @@
+package com.kueennevercry.findex.infra.openapi;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kueennevercry.findex.config.OpenApiProperties;
+import com.kueennevercry.findex.dto.response.IndexDataResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class DefaultOpenApiClient implements OpenApiClient {
+
+  private final RestTemplate restTemplate;
+  private final OpenApiProperties properties;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public List<IndexDataResponse> fetchIndexData(String indexCode, String endpoint, LocalDate from,
+      LocalDate to)
+      throws IOException, URISyntaxException {
+    URI url = buildUrl(indexCode, endpoint, from, to);
+    ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+    return convert(response.getBody());
+  }
+
+  private List<IndexDataResponse> convert(String json) throws IOException {
+    JsonNode root = objectMapper.readTree(json);
+    JsonNode items = root.path("response").path("body").path("items").path("item");
+
+    return objectMapper.readerForListOf(IndexDataResponse.class).readValue(items);
+  }
+
+  private URI buildUrl(String indexCode, String endpoint, LocalDate from, LocalDate to)
+      throws URISyntaxException {
+    String serviceKey = properties.getApiKey();
+
+    String base = properties.getBaseUrl() + endpoint
+        // endpoint: [getStockMarketIndex | getBoundMarketIndex | getDerivationProductMarketIndex]
+        + "?serviceKey=" + serviceKey
+        + "&idxNm=" + indexCode
+        + "&beginBasDt=" + from
+        + "&endBasDt=" + to
+        + "&resultType=json";
+
+    // + 기호는 인코딩에서 제외되기 때문에 미리 변환하고
+    // URI 클래스를 사용하면 URL 전송 할 때 문자열 그대로 날아가는 것이 아닌, 한 번 인코딩을 해서 보내준다
+    return new URI(base.replace("+", "%2B"));
+  }
+}

--- a/src/main/java/com/kueennevercry/findex/infra/openapi/DefaultOpenApiClient.java
+++ b/src/main/java/com/kueennevercry/findex/infra/openapi/DefaultOpenApiClient.java
@@ -46,7 +46,7 @@ public class DefaultOpenApiClient implements OpenApiClient {
     String base = properties.getBaseUrl() + endpoint
         // endpoint: [getStockMarketIndex | getBoundMarketIndex | getDerivationProductMarketIndex]
         + "?serviceKey=" + serviceKey
-        + "&idxNm=" + indexCode
+//        + "&idxNm=" + indexCode
         + "&beginBasDt=" + from
         + "&endBasDt=" + to
         + "&resultType=json";

--- a/src/main/java/com/kueennevercry/findex/infra/openapi/OpenApiClient.java
+++ b/src/main/java/com/kueennevercry/findex/infra/openapi/OpenApiClient.java
@@ -1,0 +1,14 @@
+package com.kueennevercry.findex.infra.openapi;
+
+import com.kueennevercry.findex.dto.response.IndexDataResponse;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface OpenApiClient {
+
+  List<IndexDataResponse> fetchIndexData(String indexCode, String endpoint, LocalDate from,
+      LocalDate to)
+      throws IOException, URISyntaxException;
+}

--- a/src/main/java/com/kueennevercry/findex/service/IndexChartService.java
+++ b/src/main/java/com/kueennevercry/findex/service/IndexChartService.java
@@ -1,0 +1,12 @@
+package com.kueennevercry.findex.service;
+
+import com.kueennevercry.findex.dto.PeriodType;
+import com.kueennevercry.findex.dto.response.IndexChartResponse;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+public interface IndexChartService {
+
+  IndexChartResponse getChart(Long indexInfoId, PeriodType periodType)
+      throws IOException, URISyntaxException;
+}

--- a/src/main/java/com/kueennevercry/findex/service/IndexChartServiceImpl.java
+++ b/src/main/java/com/kueennevercry/findex/service/IndexChartServiceImpl.java
@@ -1,0 +1,69 @@
+package com.kueennevercry.findex.service;
+
+import com.kueennevercry.findex.dto.ChartPoint;
+import com.kueennevercry.findex.dto.PeriodType;
+import com.kueennevercry.findex.dto.response.IndexChartResponse;
+import com.kueennevercry.findex.dto.response.IndexDataResponse;
+import com.kueennevercry.findex.infra.openapi.OpenApiClient;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.URISyntaxException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IndexChartServiceImpl implements IndexChartService {
+
+  private final OpenApiClient openApiClient;
+  private String STOCK_INDEX_ENDPOINT = "/getStockMarketIndex";
+
+  @Override
+  public IndexChartResponse getChart(Long indexInfoId, PeriodType periodType)
+      throws IOException, URISyntaxException {
+    // 임의의 값으로 테스트
+    String indexCode = "KRX 300 소재";
+    LocalDate endDate = LocalDate.now();
+    LocalDate startDate = endDate.minusMonths(6);
+
+    List<IndexDataResponse> rawData = openApiClient.fetchIndexData(indexCode, STOCK_INDEX_ENDPOINT,
+        startDate,
+        endDate);
+
+    List<ChartPoint> dataPoints = rawData.stream()
+        .map(data -> new ChartPoint(data.baseDate(), data.closingPrice()))
+        .sorted(Comparator.comparing(ChartPoint::date).reversed())
+        .toList();
+
+    List<ChartPoint> ma5 = calculateMovingAverage(dataPoints, 5);
+    List<ChartPoint> ma20 = calculateMovingAverage(dataPoints, 20);
+
+    return new IndexChartResponse(
+        indexInfoId,
+        "KRX 시리즈",
+        "KRX 300 소재",
+        periodType,
+        dataPoints,
+        ma5,
+        ma20
+    );
+  }
+
+  private List<ChartPoint> calculateMovingAverage(List<ChartPoint> points, int windowSize) {
+    List<ChartPoint> result = new ArrayList<>();
+    for (int i = 0; i <= points.size() - windowSize; i++) {
+      BigDecimal sum = BigDecimal.ZERO;
+      for (int j = 0; j < windowSize; j++) {
+        sum = sum.add(points.get(i + j).value());
+      }
+      BigDecimal average = sum.divide(BigDecimal.valueOf(windowSize), RoundingMode.HALF_UP);
+      result.add(new ChartPoint(points.get(i).date(), average));
+    }
+    return result;
+  }
+}

--- a/src/main/java/com/kueennevercry/findex/service/IndexDataService.java
+++ b/src/main/java/com/kueennevercry/findex/service/IndexDataService.java
@@ -5,7 +5,7 @@ import com.kueennevercry.findex.dto.response.IndexChartResponse;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-public interface IndexChartService {
+public interface IndexDataService {
 
   IndexChartResponse getChart(Long indexInfoId, PeriodType periodType)
       throws IOException, URISyntaxException;

--- a/src/main/java/com/kueennevercry/findex/service/IndexDataServiceImpl.java
+++ b/src/main/java/com/kueennevercry/findex/service/IndexDataServiceImpl.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class IndexChartServiceImpl implements IndexChartService {
+public class IndexDataServiceImpl implements IndexDataService {
 
   private final OpenApiClient openApiClient;
   private String STOCK_INDEX_ENDPOINT = "/getStockMarketIndex";

--- a/src/main/java/com/kueennevercry/findex/service/Service.java
+++ b/src/main/java/com/kueennevercry/findex/service/Service.java
@@ -1,5 +1,0 @@
-package com.kueennevercry.findex.service;
-
-public class Service {
-
-}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,15 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+    open-in-view: false
 
-# DB config
+  # DB config
   config:
     import: "classpath:db.yaml"
+
+# Open API
+# 개발 환경: Run > Edit Configurations > Environment variables에 `OPEN_API_KEY=발급 받은 키`를 등록합니다.
+# 운영 환경: OS 환경 변수 등록 또는 dotenv-spring-boot 외부 라이브러리를 고려합니다.
+openapi:
+  base-url: https://apis.data.go.kr/1160100/service/GetMarketIndexInfoService
+  api-key: ${OPEN_API_KEY}

--- a/src/test/resources/http/index-data-chart.http
+++ b/src/test/resources/http/index-data-chart.http
@@ -1,0 +1,3 @@
+### 지수 차트 조회 테스트
+GET http://localhost:8080/api/index-data/5/chart?periodType=YEARLY
+Content-Type: application/json


### PR DESCRIPTION
## 📝 변경사항 요약

### application.yaml

- base-url 정의, 추가적인 엔드포인트는 호출 시 지정할 수 있게 유연한 구조로 구성.
- API 키를 환경 변수 `OPEN_API_KEY`로 관리 할 수 있게 보안과 이식성 확보
  - 개발 환경: Run > Edit Configurations > Environment variables에 `OPEN_API_KEY=발급 받은 키`를 등록합니다.
  - 운영 환경: OS 환경 변수 등록 또는 dotenv-spring-boot 외부 라이브러리를 고려합니다.

### db.yaml

- 팀원 로컬 DB 구성을 모르는 상황이라서 커밋에서 제외
- 각자 구성한 설정으로 사용 요망.
 
### OpenAPIProperties

- `.yaml`에 정의한 API 관련 설정을 `@ConfigurationProperties`로 바인딩

### OpenApiClient

- 테스트 가능성과 관심사 분리를 위해 `OpenApiClient` 인터페이스 사용

### DefaultOpenApiClient

- `RestTemplate`으로 외부 API 요청을 수행하는 구현체
- 외부 API는 서비스 키에 대해 인코딩하면 오류 발생: `SERVICE_KEY_IS_NOT_REGISTERED_ERROR` 대응

그 외 Open API 사용 구성과 관련된 파일들이 추가되었습니다.

## 📋 체크리스트
- [x] 지수의 차트 데이터를 조회합니다.
- [x] 지수 정보 ID, 차트 기간 유형으로 데이터를 조회합니다.

## 🔗 관련 이슈

[Feature] 지수 차트 조회 [#15](https://github.com/Kueen-never-cry/sb03-findex-team1/issues/15)

## 💬 추가 설명

- OpenApi 관련해서 Client를 생성했는데 유연하게 다른 곳에서도 확장할 수 있는 방법이 있다면 코멘트 부탁 드립니다.
- 현재 PR은 통신 테스트가 주 목적인 관계로 지수 정보가 있어야 프론트 차트 조회가 가능할 것으로 예상됩니다.
  - Dummy Data 추가로 테스트가 가능한지 확인해보겠습니다.
- 작업 중이신 내용과 중복되거나 본인에겐 불필요한 파일이 있을 수 있습니다. 구조 변경에 있어서 자유롭게 다양한 의견을 남겨주시면 감사하겠습니다. 😊

![image](https://github.com/user-attachments/assets/2291b432-ab8c-4d1b-b7ff-94c7c929c8d8)