### PR TITLE
Feat/지수 정보 조회 GET API 엔드포인트 구현

### DIFF
--- a/src/main/java/com/kueennevercry/findex/controller/IndexInfoController.java
+++ b/src/main/java/com/kueennevercry/findex/controller/IndexInfoController.java
@@ -1,0 +1,25 @@
+package com.kueennevercry.findex.controller;
+
+import com.kueennevercry.findex.dto.IndexInfoDto;
+import com.kueennevercry.findex.service.IndexInfoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/index-infos")
+@RequiredArgsConstructor
+public class IndexInfoController {
+
+  private final IndexInfoService indexInfoService;
+
+  /**
+   * 특정 ID의 지수 정보 조회
+   * GET /api/index-infos/{id}
+   */
+  @GetMapping("/{id}")
+  public ResponseEntity<IndexInfoDto> getIndexInfo(@PathVariable Long id) {
+    IndexInfoDto indexInfo = indexInfoService.findById(id);
+    return ResponseEntity.ok(indexInfo);
+  }
+}

--- a/src/main/java/com/kueennevercry/findex/dto/IndexInfoDto.java
+++ b/src/main/java/com/kueennevercry/findex/dto/IndexInfoDto.java
@@ -1,0 +1,43 @@
+package com.kueennevercry.findex.dto;
+
+import com.kueennevercry.findex.entity.IndexInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IndexInfoDto {
+
+  private Long id;
+  private String indexClassification;
+  private String indexName;
+  private Integer employedItemsCount;
+  private LocalDate basePointInTime;
+  private Float baseIndex;
+  private IndexInfo.SourceType sourceType;
+  private Boolean favorite;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public static IndexInfoDto from(IndexInfo indexInfo) {
+    return IndexInfoDto.builder()
+        .id(indexInfo.getId())
+        .indexClassification(indexInfo.getIndexClassification())
+        .indexName(indexInfo.getIndexName())
+        .employedItemsCount(indexInfo.getEmployedItemsCount())
+        .basePointInTime(indexInfo.getBasePointInTime())
+        .baseIndex(indexInfo.getBaseIndex())
+        .sourceType(indexInfo.getSourceType())
+        .favorite(indexInfo.getFavorite())
+        .createdAt(indexInfo.getCreatedAt())
+        .updatedAt(indexInfo.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/kueennevercry/findex/entity/IndexInfo.java
+++ b/src/main/java/com/kueennevercry/findex/entity/IndexInfo.java
@@ -35,8 +35,9 @@ public class IndexInfo {
 
   @Column(name = "base_index", nullable = false)
   private Float baseIndex;
-
-  @Column(name = "source_type", nullable = false, length = 32, columnDefinition = "VARCHAR(32) CHECK (source_type IN ('USER', 'OPEN_API'))")
+  
+  @Enumerated(EnumType.STRING)
+  @Column(name = "source_type", nullable = false, length = 32)
   private SourceType sourceType;
 
   @Column(name = "favorite")

--- a/src/main/java/com/kueennevercry/findex/entity/IndexInfo.java
+++ b/src/main/java/com/kueennevercry/findex/entity/IndexInfo.java
@@ -1,0 +1,64 @@
+package com.kueennevercry.findex.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "index_info")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IndexInfo {
+
+  @Id // Primary Key
+  @GeneratedValue(strategy = GenerationType.IDENTITY) // BIGSERIAL(AUTO_INCREMENT)
+  private Long id;
+
+  @Column(name = "index_classification", nullable = false, length = 32)
+  private String indexClassification;
+
+  @Column(name = "index_name", nullable = false, length = 100)
+  private String indexName;
+
+  @Column(name = "employed_items_count", nullable = false)
+  private Integer employedItemsCount;
+
+  @Column(name = "base_point_in_time", nullable = false)
+  private LocalDate basePointInTime;
+
+  @Column(name = "base_index", nullable = false)
+  private Float baseIndex;
+
+  @Column(name = "source_type", nullable = false, length = 32, columnDefinition = "VARCHAR(32) CHECK (source_type IN ('USER', 'OPEN_API'))")
+  private SourceType sourceType;
+
+  @Column(name = "favorite")
+  private Boolean favorite;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  @PrePersist // 데이터 생성 시 자동으로 실행
+  protected void onCreate() {
+    createdAt = LocalDateTime.now();
+  }
+
+  @PreUpdate // 데이터 수정 시 자동으로 실행
+  protected void onUpdate() {
+    updatedAt = LocalDateTime.now();
+  }
+
+  public enum SourceType {
+    USER, OPEN_API
+  }
+}

--- a/src/main/java/com/kueennevercry/findex/repository/IndexInfoRepository.java
+++ b/src/main/java/com/kueennevercry/findex/repository/IndexInfoRepository.java
@@ -1,0 +1,23 @@
+package com.kueennevercry.findex.repository;
+
+import com.kueennevercry.findex.entity.IndexInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IndexInfoRepository extends JpaRepository<IndexInfo, Long> {
+
+  /**
+   * IndexInfoRepository는 JpaRepository를 상속받아 기본적인 CRUD 연산을 제공합니다.
+   * 
+   * JpaRepository -> ListCrudRepository -> CrudRepository 계층 구조를 통해 다음과 같은 메서드들이
+   * 자동으로 제공됩니다:
+   * - Optional<IndexInfo> findById(Long id): ID로 엔티티 조회 (Optional 반환으로 null 안전성
+   * 보장)
+   * - List<IndexInfo> findAll(): 모든 엔티티 조회
+   * - IndexInfo save(IndexInfo entity): 엔티티 저장/수정
+   * - void deleteById(Long id): ID로 엔티티 삭제
+   * - boolean existsById(Long id): ID 존재 여부 확인
+   */
+
+}

--- a/src/main/java/com/kueennevercry/findex/repository/Repository.java
+++ b/src/main/java/com/kueennevercry/findex/repository/Repository.java
@@ -1,5 +1,0 @@
-package com.kueennevercry.findex.repository;
-
-public class Repository {
-
-}

--- a/src/main/java/com/kueennevercry/findex/service/IndexInfoService.java
+++ b/src/main/java/com/kueennevercry/findex/service/IndexInfoService.java
@@ -1,0 +1,25 @@
+package com.kueennevercry.findex.service;
+
+import com.kueennevercry.findex.dto.IndexInfoDto;
+import com.kueennevercry.findex.entity.IndexInfo;
+import com.kueennevercry.findex.repository.IndexInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IndexInfoService {
+
+  private final IndexInfoRepository indexInfoRepository;
+
+  /**
+   * ID로 지수 정보 조회
+   */
+  public IndexInfoDto findById(Long id) {
+    IndexInfo indexInfo = indexInfoRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("지수 정보를 찾을 수 없습니다. ID: " + id));
+    return IndexInfoDto.from(indexInfo);
+  }
+}

--- a/src/test/resources/http/index-data-chart.http
+++ b/src/test/resources/http/index-data-chart.http
@@ -1,3 +1,6 @@
 ### 지수 차트 조회 테스트
 GET http://localhost:8080/api/index-data/5/chart?periodType=YEARLY
 Content-Type: application/json
+
+### 지수 정보 조회 테스트
+GET http://localhost:8080/api/index-infos/173


### PR DESCRIPTION
## 📝 변경사항 요약
지수 정보 조회를 위한 GET API 엔드포인트를 구현했습니다.

## 📋 체크리스트
- [x] 엔티티 및 DTO 구현
- [x] Repository 인터페이스 생성
- [x] Service 비즈니스 로직 구현
- [x] Controller REST API 구현
- [x] HTTP 테스트 파일 작성
- [x] 로컬 테스트 완료

## API Endpoint
- `GET /api/index-infos/{id}` - 특정 ID의 지수 정보 조회

## Testing
- 수동 테스트 가능한 샘플 요청 추가.

## 🔍 API Response Example
```json
{
  "id": 173,
  "indexClassification": "테마분류",
  "indexName": "코스피 고배당 50",
  "employedItemsCount": 10,
  "basePointInTime": "2025-06-04",
  "baseIndex": 1010.0,
  "sourceType": "USER",
  "favorite": true,
  "createdAt": "2025-06-05T07:23:57.729198",
  "updatedAt": null
}
```
## 🔗 관련 이슈
Closes #8  

## 💬 추가 설명
지수 데이터 api를 테스트하던 HTTP 테스트 파일(`index-data-chart.http`)에 지수 정보 조회 api 테스트 요청을 추가했습니다. 지수 정보, 지수 데이터, 연동 관리, 자동 연동 관리 http 테스트 파일을 생성하기보단 기존의 테스트 파일을 통합 테스트 파일로 변경하고 한 파일에서 관리하는 것이 좋을 것 같았습니다. 그래서 지수 정보 테스트 http 파일을 생성하지 않고 기존의 테스트 파일에 추가했습니다.
