### PR TITLE
Feat/자동 연동 설정 수정 [PATCH API 엔드포인트 구현]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+db.yaml
+application.yaml
 
 ### NetBeans ###
 /nbproject/private/

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/kueennevercry/findex/FindexApplication.java
+++ b/src/main/java/com/kueennevercry/findex/FindexApplication.java
@@ -2,6 +2,7 @@ package com.kueennevercry.findex;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @SpringBootApplication
 public class FindexApplication {

--- a/src/main/java/com/kueennevercry/findex/controller/AutoSyncConfigController.java
+++ b/src/main/java/com/kueennevercry/findex/controller/AutoSyncConfigController.java
@@ -1,0 +1,30 @@
+package com.kueennevercry.findex.controller;
+
+import com.kueennevercry.findex.dto.AutoSyncConfigDto;
+import com.kueennevercry.findex.dto.request.AutoSyncConfigUpdateRequest;
+import com.kueennevercry.findex.service.AutoSyncConfigService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auto-sync-configs")
+@RequiredArgsConstructor
+public class AutoSyncConfigController {
+
+  private final AutoSyncConfigService autoSyncConfigService;
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<AutoSyncConfigDto> updateAutoSyncConfig(
+      @PathVariable("id") Long id,
+      @RequestBody AutoSyncConfigUpdateRequest request
+  ) {
+    AutoSyncConfigDto updated = autoSyncConfigService.updateEnabled(id, request.getEnabled());
+    return ResponseEntity.status(HttpStatus.OK).body(updated);
+  }
+}

--- a/src/main/java/com/kueennevercry/findex/dto/IndexInfoSummaryDto.java
+++ b/src/main/java/com/kueennevercry/findex/dto/IndexInfoSummaryDto.java
@@ -1,0 +1,8 @@
+package com.kueennevercry.findex.dto;
+
+public record IndexInfoSummaryDto(
+
+    Long id,
+    String indexName,
+    String indexClassification
+) {}

--- a/src/main/java/com/kueennevercry/findex/dto/request/AutoSyncConfigUpdateRequest.java
+++ b/src/main/java/com/kueennevercry/findex/dto/request/AutoSyncConfigUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.kueennevercry.findex.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AutoSyncConfigUpdateRequest {
+  private Boolean enabled;
+}

--- a/src/main/java/com/kueennevercry/findex/mapper/AutoSyncConfigMapper.java
+++ b/src/main/java/com/kueennevercry/findex/mapper/AutoSyncConfigMapper.java
@@ -2,18 +2,19 @@ package com.kueennevercry.findex.mapper;
 
 import com.kueennevercry.findex.config.AutoSyncConfig;
 import com.kueennevercry.findex.dto.AutoSyncConfigDto;
+import com.kueennevercry.findex.dto.IndexInfoSummaryDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface AutoSyncConfigMapper {
 
-  @Mapping(target = "indexInfoId", expression = "java(config.getIndexInfo().getId())")
-  @Mapping(target = "indexClassification", source = "indexClassification")
-  @Mapping(target = "indexName", source = "indexName")
+  @Mapping(target = "id", source = "config.id")
+  @Mapping(target = "indexInfoId", source = "indexInfo.id")
+  @Mapping(target = "indexName", source = "indexInfo.indexName")
+  @Mapping(target = "indexClassification", source = "indexInfo.indexClassification")
   AutoSyncConfigDto toDto(
       AutoSyncConfig config,
-      String indexClassification,
-      String indexName
+      IndexInfoSummaryDto indexInfo
   );
 }

--- a/src/main/java/com/kueennevercry/findex/service/AutoSyncConfigService.java
+++ b/src/main/java/com/kueennevercry/findex/service/AutoSyncConfigService.java
@@ -2,13 +2,14 @@ package com.kueennevercry.findex.service;
 
 import com.kueennevercry.findex.config.AutoSyncConfig;
 import com.kueennevercry.findex.dto.AutoSyncConfigDto;
+import com.kueennevercry.findex.dto.IndexInfoSummaryDto;
 import com.kueennevercry.findex.entity.IndexInfo;
 import com.kueennevercry.findex.mapper.AutoSyncConfigMapper;
 import com.kueennevercry.findex.repository.AutoSyncConfigRepository;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,10 +26,11 @@ public class AutoSyncConfigService {
     config.setEnabled(enabled);
 
     IndexInfo index = config.getIndexInfo();
-    return autoSyncConfigMapper.toDto(
-        config,
-        index.getIndexClassification(),
-        index.getIndexName()
+    IndexInfoSummaryDto indexInfoDto = new IndexInfoSummaryDto(
+        index.getId(),
+        index.getIndexName(),
+        index.getIndexClassification()
     );
+    return autoSyncConfigMapper.toDto(config, indexInfoDto);
   }
 }

--- a/src/main/java/com/kueennevercry/findex/service/AutoSyncConfigService.java
+++ b/src/main/java/com/kueennevercry/findex/service/AutoSyncConfigService.java
@@ -31,5 +31,4 @@ public class AutoSyncConfigService {
         index.getIndexName()
     );
   }
-
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,11 +1,11 @@
 spring:
   application:
     name: findex
-  datasource:
-    url: jdbc:postgresql://localhost:5432/findex
-    username: postgres
-    password: 1234
-    driver-class-name: org.postgresql.Driver
+#  datasource:
+#    url: jdbc:postgresql://localhost:5432/findex
+#    username: postgres
+#    password: 1234
+#    driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/db.yaml
+++ b/src/main/resources/db.yaml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url:
-    username:
-    password:
+    url: jdbc:postgresql://localhost:5432/findex
+    username: postgres
+    password: System1234
     driver-class-name: org.postgresql.Driver
 
   jpa:

--- a/src/main/resources/http/auto-sync-config-update.http
+++ b/src/main/resources/http/auto-sync-config-update.http
@@ -1,0 +1,6 @@
+PATCH http://localhost:8080/api/auto-sync-configs/1
+Content-Type: application/json
+
+{
+  "enabled": true
+}


### PR DESCRIPTION
## 📝 변경사항 요약
- 자동 연동 설정 수정 기능 구현 (PATCH /auto-sync-configs/{id})
  - enabled 필드 값 수정
  - 존재하지 않는 ID에 대해 예외처리
- AutoSyncConfigUpdateRequest 요청 DTO 추가
- 응답 DTO인 AutoSyncConfigDto`정의 및 활용
  - indexInfo의 indexName, indexClassification 포함
- AutoSyncConfigMapper에서 index 관련 필드들을 개별 파라미터로 전달하던 방식을
  → IndexInfoSummaryDto로 묶어서 전달하도록 리팩토링
- Mapper 시그니처 간결화 및 향후 확장 대비 구조 개선

## 📋 체크리스트
- [x] 자동 연동 설정 수정 API 구현 (Service, Controller, DTO)
- [x] IndexInfoSummaryDto 도입 및 적용
- [x] 테스트 환경에서 PostgreSQL 연결 및 테스트 실행
- [x] AutoSyncConfigMapper 구조 개선

## 🌐 API 명세
<img width="781" alt="테스트" src="https://github.com/user-attachments/assets/56d1b5fd-3143-4356-a65f-8f99222de821" />
<img width="780" alt="결과" src="https://github.com/user-attachments/assets/a986a987-8b5b-444d-88ef-ed29c84c3bf9" />

## 🔗 관련 이슈
closes #22 

## 💬 추가 설명
- 은호님 말씀대로 Mapper 구조를 DTO로 개선하여 추후 IndexInfo의 필드 확장에도 유연하게 대응 가능하도록 설계했습니다.
