### PR TITLE
Feature/지수 정보 수정 #9

### DIFF
--- a/src/main/java/com/kueennevercry/findex/controller/IndexInfoController.java
+++ b/src/main/java/com/kueennevercry/findex/controller/IndexInfoController.java
@@ -1,12 +1,14 @@
 package com.kueennevercry.findex.controller;
 
 import com.kueennevercry.findex.dto.request.IndexInfoCreateRequest;
+import com.kueennevercry.findex.dto.request.IndexInfoUpdateRequest;
 import com.kueennevercry.findex.dto.response.IndexInfoDto;
 import com.kueennevercry.findex.service.IndexInfoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,5 +38,25 @@ public class IndexInfoController {
   public ResponseEntity<IndexInfoDto> createIndexInfo(@RequestBody IndexInfoCreateRequest request) {
     IndexInfoDto createdIndexInfo = indexInfoService.create(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(createdIndexInfo);
+  }
+
+  /**
+   * 지수 정보 수정 PATCH /api/index-infos/{id}
+   */
+  @PatchMapping("/{id}")
+  public ResponseEntity<IndexInfoDto> updateIndexInfo(
+      @PathVariable Long id,
+      @RequestBody IndexInfoUpdateRequest request) {
+
+    // 요청 데이터가 모두 null인 경우 체크
+    if (request.employedItemsCount() == null &&
+        request.basePointInTime() == null &&
+        request.baseIndex() == null &&
+        request.favorite() == null) {
+      throw new IllegalArgumentException("수정할 데이터가 없습니다.");
+    }
+
+    IndexInfoDto updatedIndexInfo = indexInfoService.update(id, request);
+    return ResponseEntity.ok(updatedIndexInfo);
   }
 }

--- a/src/main/java/com/kueennevercry/findex/dto/request/IndexInfoCreateRequest.java
+++ b/src/main/java/com/kueennevercry/findex/dto/request/IndexInfoCreateRequest.java
@@ -1,41 +1,19 @@
 package com.kueennevercry.findex.dto.request;
 
-import com.kueennevercry.findex.entity.IndexInfo;
 import com.kueennevercry.findex.entity.SourceType;
+import java.math.BigDecimal;
 import java.time.LocalDate;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class IndexInfoCreateRequest {
+/**
+ * 지수 정보 생성 요청 DTO 데이터 전달 목적으로만 사용
+ */
+public record IndexInfoCreateRequest(
+    String indexClassification,
+    String indexName,
+    Integer employedItemsCount,
+    LocalDate basePointInTime,
+    BigDecimal baseIndex,
+    SourceType sourceType,
+    Boolean favorite) {
 
-  private String indexClassification;
-  private String indexName;
-  private Integer employedItemsCount;
-  private LocalDate basePointInTime;
-  private Float baseIndex;
-  private SourceType sourceType;
-
-  @Builder.Default
-  private Boolean favorite = false; // 기본값 false
-
-  /**
-   * 요청 DTO를 엔티티로 변환
-   */
-  public IndexInfo toEntity() {
-    return IndexInfo.builder()
-        .indexClassification(this.indexClassification)
-        .indexName(this.indexName)
-        .employedItemsCount(this.employedItemsCount)
-        .basePointInTime(this.basePointInTime)
-        .baseIndex(this.baseIndex)
-        .sourceType(this.sourceType)
-        .favorite(this.favorite)
-        .build();
-  }
 }

--- a/src/main/java/com/kueennevercry/findex/dto/request/IndexInfoUpdateRequest.java
+++ b/src/main/java/com/kueennevercry/findex/dto/request/IndexInfoUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.kueennevercry.findex.dto.request;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 지수 정보 수정 요청 DTO 수정 가능한 필드: 채용 종목 수, 기준 시점, 기준 지수, 즐겨찾기
+ */
+public record IndexInfoUpdateRequest(
+    Integer employedItemsCount,
+    LocalDate basePointInTime,
+    BigDecimal baseIndex,
+    Boolean favorite) {
+
+}

--- a/src/main/java/com/kueennevercry/findex/dto/response/IndexDataDto.java
+++ b/src/main/java/com/kueennevercry/findex/dto/response/IndexDataDto.java
@@ -17,8 +17,6 @@ public record IndexDataDto(
     BigDecimal fluctuationRate,
     Long tradingQuantity,
     Long tradingPrice,
-    Long marketTotalAmount
-
-) {
+    Long marketTotalAmount) {
 
 }

--- a/src/main/java/com/kueennevercry/findex/dto/response/IndexInfoDto.java
+++ b/src/main/java/com/kueennevercry/findex/dto/response/IndexInfoDto.java
@@ -1,43 +1,23 @@
 package com.kueennevercry.findex.dto.response;
 
-import com.kueennevercry.findex.entity.IndexInfo;
 import com.kueennevercry.findex.entity.SourceType;
+import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class IndexInfoDto {
+/**
+ * 지수 정보 DTO 데이터 전달 목적으로만 사용
+ */
+public record IndexInfoDto(
+    Long id,
+    String indexClassification,
+    String indexName,
+    Integer employedItemsCount,
+    LocalDate basePointInTime,
+    BigDecimal baseIndex,
+    SourceType sourceType,
+    Boolean favorite,
+    Instant createdAt,
+    Instant updatedAt) {
 
-  private Long id;
-  private String indexClassification;
-  private String indexName;
-  private Integer employedItemsCount;
-  private LocalDate basePointInTime;
-  private Float baseIndex;
-  private SourceType sourceType;
-  private Boolean favorite;
-  private LocalDateTime createdAt;
-  private LocalDateTime updatedAt;
-
-  public static IndexInfoDto from(IndexInfo indexInfo) {
-    return IndexInfoDto.builder()
-        .id(indexInfo.getId())
-        .indexClassification(indexInfo.getIndexClassification())
-        .indexName(indexInfo.getIndexName())
-        .employedItemsCount(indexInfo.getEmployedItemsCount())
-        .basePointInTime(indexInfo.getBasePointInTime())
-        .baseIndex(indexInfo.getBaseIndex())
-        .sourceType(indexInfo.getSourceType())
-        .favorite(indexInfo.getFavorite())
-        .createdAt(indexInfo.getCreatedAt())
-        .updatedAt(indexInfo.getUpdatedAt())
-        .build();
-  }
 }

--- a/src/main/java/com/kueennevercry/findex/entity/IndexInfo.java
+++ b/src/main/java/com/kueennevercry/findex/entity/IndexInfo.java
@@ -10,12 +10,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -48,7 +48,7 @@ public class IndexInfo {
   private LocalDate basePointInTime;
 
   @Column(name = "base_index", nullable = false)
-  private Float baseIndex;
+  private BigDecimal baseIndex;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "source_type", nullable = false, length = 32)
@@ -58,18 +58,18 @@ public class IndexInfo {
   private Boolean favorite;
 
   @Column(name = "created_at", nullable = false)
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   @Column(name = "updated_at")
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 
   @PrePersist // 데이터 생성 시 자동으로 실행
   protected void onCreate() {
-    createdAt = LocalDateTime.now();
+    createdAt = Instant.now();
   }
 
   @PreUpdate // 데이터 수정 시 자동으로 실행
   protected void onUpdate() {
-    updatedAt = LocalDateTime.now();
+    updatedAt = Instant.now();
   }
 }

--- a/src/main/java/com/kueennevercry/findex/mapper/IndexInfoMapper.java
+++ b/src/main/java/com/kueennevercry/findex/mapper/IndexInfoMapper.java
@@ -1,10 +1,21 @@
 package com.kueennevercry.findex.mapper;
 
+import com.kueennevercry.findex.dto.request.IndexInfoCreateRequest;
 import com.kueennevercry.findex.dto.response.IndexInfoDto;
 import com.kueennevercry.findex.entity.IndexInfo;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.springframework.stereotype.Component;
 
+/**
+ * IndexInfo 엔티티와 IndexInfoDto 간의 변환 매퍼 변환 책임을 분리하여 단일 책임 원칙(SRP) 준수
+ * <p>
+ * 주요 기능: Entity ↔ DTO 변환 책임 분리 (단일 책임 원칙) 컴파일 시점에 MapStruct가 자동으로 구현체 생성 같은 이름의 필드는 자동 매핑, null 안전성
+ * 보장
+ * <p>
+ * 변환 방식: Entity → DTO: Entity의 각 필드를 개별 변수로 추출 후 record 생성자 직접 호출 • DTO → Entity: DTO의 각 필드를 개별 변수로
+ * 추출 후 Entity의 Builder 패턴 사용
+ */
 @Component
 @Mapper(componentModel = "spring")
 public interface IndexInfoMapper {
@@ -12,5 +23,9 @@ public interface IndexInfoMapper {
   IndexInfoDto toDto(IndexInfo indexInfo);
 
   IndexInfo toEntity(IndexInfoDto indexInfoDto);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "createdAt", ignore = true)
+  IndexInfo toEntity(IndexInfoCreateRequest request);
 
 }

--- a/src/main/java/com/kueennevercry/findex/service/IndexInfoService.java
+++ b/src/main/java/com/kueennevercry/findex/service/IndexInfoService.java
@@ -2,7 +2,9 @@ package com.kueennevercry.findex.service;
 
 import com.kueennevercry.findex.dto.request.IndexInfoCreateRequest;
 import com.kueennevercry.findex.dto.response.IndexInfoDto;
+import com.kueennevercry.findex.dto.request.IndexInfoUpdateRequest;
 import com.kueennevercry.findex.entity.IndexInfo;
+import com.kueennevercry.findex.mapper.IndexInfoMapper;
 import com.kueennevercry.findex.repository.IndexInfoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class IndexInfoService {
 
   private final IndexInfoRepository indexInfoRepository;
+  private final IndexInfoMapper indexInfoMapper;
 
   /**
    * ID로 지수 정보 조회
@@ -21,7 +24,7 @@ public class IndexInfoService {
   public IndexInfoDto findById(Long id) {
     IndexInfo indexInfo = indexInfoRepository.findById(id)
         .orElseThrow(() -> new RuntimeException("지수 정보를 찾을 수 없습니다. ID: " + id));
-    return IndexInfoDto.from(indexInfo);
+    return indexInfoMapper.toDto(indexInfo);
   }
 
   /**
@@ -31,15 +34,55 @@ public class IndexInfoService {
   public IndexInfoDto create(IndexInfoCreateRequest request) {
     // 지수명과 지수 분류명 조합 중복 검증
     if (indexInfoRepository.existsByIndexNameAndIndexClassification(
-        request.getIndexName(), request.getIndexClassification())) {
+        request.indexName(), request.indexClassification())) {
       throw new RuntimeException("이미 존재하는 지수명과 분류 조합입니다. 지수명: "
-          + request.getIndexName() + ", 분류: " + request.getIndexClassification());
+          + request.indexName() + ", 분류: " + request.indexClassification());
     }
 
-    // 요청 DTO를 엔티티로 변환 후 저장
-    IndexInfo indexInfo = request.toEntity();
+    // 요청 DTO를 엔티티로 변환 후 저장 (Mapper 사용)
+    IndexInfo indexInfo = indexInfoMapper.toEntity(request);
     IndexInfo savedIndexInfo = indexInfoRepository.save(indexInfo);
 
-    return IndexInfoDto.from(savedIndexInfo);
+    return indexInfoMapper.toDto(savedIndexInfo);
+  }
+
+  /**
+   * 지수 정보 수정
+   *
+   * JPA 더티 체킹(Dirty Checking) 활용
+   * - findById()로 조회한 엔티티는 영속성 컨텍스트에서 관리됨
+   * - 엔티티 필드 변경 시 JPA가 자동으로 변경사항을 감지
+   * - @Transactional 메서드 종료 시점에 자동으로 UPDATE 쿼리 실행
+   * - 따라서 repository.save() 호출이 불필요함
+   *
+   * 주의사항:
+   * - @Transactional 어노테이션이 반드시 필요
+   * - findById()로 조회한 영속 상태의 엔티티여야 함
+   * - 변경된 필드만 UPDATE 쿼리에 포함되어 성능상 유리
+   */
+  @Transactional // 오버라이드: readOnly = false
+  public IndexInfoDto update(Long id, IndexInfoUpdateRequest request) {
+    // 1. 기존 지수 정보 조회 (영속성 컨텍스트에 엔티티 저장 + 스냅샷 생성)
+    IndexInfo indexInfo = indexInfoRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("지수 정보를 찾을 수 없습니다. ID: " + id));
+
+    // 2. 수정 가능한 필드만 업데이트 (null이 아닌 경우에만)
+    // 각 setter 호출 시 JPA가 변경사항을 감지함
+    if (request.employedItemsCount() != null) {
+      indexInfo.setEmployedItemsCount(request.employedItemsCount());
+    }
+    if (request.basePointInTime() != null) {
+      indexInfo.setBasePointInTime(request.basePointInTime());
+    }
+    if (request.baseIndex() != null) {
+      indexInfo.setBaseIndex(request.baseIndex());
+    }
+    if (request.favorite() != null) {
+      indexInfo.setFavorite(request.favorite());
+    }
+
+    // 3. 메서드 종료 시 @Transactional에 의해 자동으로 UPDATE 쿼리 실행
+    // repository.save() 호출 불필요 (더티 체킹이 자동 처리)
+    return indexInfoMapper.toDto(indexInfo);
   }
 }

--- a/src/test/resources/http/index-infos.http
+++ b/src/test/resources/http/index-infos.http
@@ -7,10 +7,21 @@ Content-Type: application/json
 
 {
   "indexClassification": "테마분류",
-  "indexName": "나스닥100",
-  "employedItemsCount": 50,
+  "indexName": "s&p100",
+  "employedItemsCount": 100,
   "basePointInTime": "2024-01-01",
-  "baseIndex": 1000.0,
+  "baseIndex": 6000.0,
   "sourceType": "USER",
+  "favorite": false
+}
+
+### 지수 정보 수정 테스트 - 전체 필드 수정
+PATCH http://localhost:8080/api/index-infos/187
+Content-Type: application/json
+
+{
+  "employedItemsCount": 100,
+  "basePointInTime": "2024-02-10",
+  "baseIndex": 8000,
   "favorite": true
 }


### PR DESCRIPTION
## 📝 변경사항 요약
기존의 지수 정보를 수정하기 위한 PATCH API 엔드포인트를 구현했습니다. 

## 🚀 주요 기능
- **지수 정보 수정 API**: `PATCH /api/index-infos/{id}`
- **부분 수정 지원**: null이 아닌 필드만 선택적 수정
- **JPA 더티 체킹**: 자동 변경 감지 및 업데이트
- **MapStruct 매퍼**: 타입 안전한 DTO ↔ Entity 변환


## 📋 구현 체크리스트
- [x] IndexInfo 엔티티 및 기본 DTO 구현
- [x] IndexInfoUpdateRequest 수정 요청 DTO 추가
- [x] MapStruct 매퍼 인터페이스 구현 및 변환 메서드 추가
- [x] IndexInfoService 수정 로직 구현 (더티 체킹 활용)
- [x] PATCH API Controller 구현
- [x] HTTP 테스트 파일 작성 및 검증

## 🌐 API 명세
### Request
```http
POST /api/index-infos
Content-Type: application/json
{
  "id": 187,
  "indexClassification": "테마분류",
  "indexName": "나스닥100",
  "employedItemsCount": 50,
  "basePointInTime": "2024-01-01",
  "baseIndex": 1000.0,
  "sourceType": "USER",
  "favorite": true
}
```
### Response: (200 OK)
```json
{
  "id": 187,
  "indexClassification": "테마분류",
  "indexName": "s&p100",
  "employedItemsCount": 100,
  "basePointInTime": "2024-02-10",
  "baseIndex": 8000,
  "sourceType": "USER",
  "favorite": true,
  "createdAt": "2025-06-10T08:24:51.683809Z",
  "updatedAt": "2025-06-10T09:03:23.484484Z"
}
```

## 🧪 테스트
- ✅ 부분 수정 기능 검증
- ✅ 전체 필드 수정 검증  
- ✅ 빈 요청 데이터 검증 (400 Bad Request)
- ✅ 존재하지 않는 ID 검증 (404 Not Found)

## 🔗 관련 이슈
Closes #9 지수 정보 수정

## 💬 추가 설명

