### PR TITLE
Feature/지수 데이터 CSV Export

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    // OpenCSV
+    implementation 'com.opencsv:opencsv:5.9'
 }
 
 // QueryDsl : 자동 생성 소스 파일 저장 위치

--- a/src/main/java/com/kueennevercry/findex/controller/IndexDataController.java
+++ b/src/main/java/com/kueennevercry/findex/controller/IndexDataController.java
@@ -9,11 +9,18 @@ import com.kueennevercry.findex.dto.response.IndexPerformanceDto;
 import com.kueennevercry.findex.dto.response.RankedIndexPerformanceDto;
 import com.kueennevercry.findex.entity.IndexData;
 import com.kueennevercry.findex.service.IndexDataService;
+import com.opencsv.CSVWriter;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -97,6 +104,37 @@ public class IndexDataController {
       @RequestParam(defaultValue = "DAILY") PeriodType periodType
   ) {
     return indexDataService.getFavoritePerformances(periodType);
+  }
+
+  @GetMapping("/export/csv")
+  public void exportIndexDataToCsv(
+      @RequestParam(required = false) Long indexInfoId,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+      @RequestParam(defaultValue = "baseDate") String sortField,
+      @RequestParam(defaultValue = "desc") String sortDirection,
+      HttpServletResponse response
+  ) throws IOException {
+    Sort.Direction direction = Sort.Direction.fromString(sortDirection);
+    Sort sort = Sort.by(direction, sortField);
+
+    String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    String filename = "index-data-export-" + today + ".csv";
+    String encodedFilename = URLEncoder.encode(filename, StandardCharsets.UTF_8);
+
+    response.setContentType("text/csv; charset=UTF-8");
+    response.setHeader("Content-Disposition", "attachment; filename=\"" + encodedFilename + "\"");
+
+    OutputStreamWriter writer = new OutputStreamWriter(response.getOutputStream(),
+        StandardCharsets.UTF_8);
+    writer.write('\uFEFF');
+
+    List<String[]> csvData = indexDataService.getExportableIndexData(indexInfoId, startDate,
+        endDate, sort);
+
+    try (CSVWriter csvWriter = new CSVWriter(writer)) {
+      csvWriter.writeAll(csvData);
+    }
   }
 }
 

--- a/src/main/java/com/kueennevercry/findex/repository/IndexDataRepository.java
+++ b/src/main/java/com/kueennevercry/findex/repository/IndexDataRepository.java
@@ -24,7 +24,10 @@ public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
   boolean existsByBaseDate(LocalDate baseDate);
 
   @Query("SELECT MAX(d.baseDate) FROM IndexData d")
-  LocalDate findLatestBaseDateAcrossAll();
+  Optional<LocalDate> findMaxBaseDate();
+
+  @Query("SELECT MIN(d.baseDate) FROM IndexData d WHERE d.indexInfo.id = :indexInfoId")
+  Optional<LocalDate> findMinBaseDate(@Param("indexInfoId") Long indexInfoId);
 
   @Query("SELECT d FROM IndexData d WHERE d.indexInfo.id = :indexInfoId AND d.baseDate = :baseDate")
   Optional<IndexData> findByIndexInfoIdAndBaseDate(Long indexInfoId, LocalDate baseDate);
@@ -72,7 +75,4 @@ public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
       @Param("beforeBaseDate") LocalDate beforeBaseDate,
       @Param("indexInfoId") Long indexInfoId
   );
-
-  @Query("SELECT MAX(d.baseDate) FROM IndexData d")
-  Optional<LocalDate> findMaxBaseDate();
 }

--- a/src/main/java/com/kueennevercry/findex/service/IndexDataService.java
+++ b/src/main/java/com/kueennevercry/findex/service/IndexDataService.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.data.domain.Sort;
 
 public interface IndexDataService {
 
@@ -33,4 +34,7 @@ public interface IndexDataService {
       int limit);
 
   List<IndexPerformanceDto> getFavoritePerformances(PeriodType periodType);
+
+  List<String[]> getExportableIndexData(Long indexInfoId, LocalDate startDate,
+      LocalDate endDate, Sort sort);
 }

--- a/src/main/java/com/kueennevercry/findex/service/IndexDataServiceImpl.java
+++ b/src/main/java/com/kueennevercry/findex/service/IndexDataServiceImpl.java
@@ -203,16 +203,14 @@ public class IndexDataServiceImpl implements IndexDataService {
 
     if (startDate == null) {
       startDate = indexDataRepository.findMinBaseDate(indexInfoId)
-          .orElseThrow(() -> new NoSuchElementException("해당 지수의 데이터가 존재하지 않습니다."));
+          .orElseThrow(() -> new IllegalStateException("지수 데이터가 없습니다."));
     }
 
     List<IndexData> dataList = indexDataRepository.findAllByIndexInfo_IdAndBaseDateBetween(
         indexInfoId, startDate, endDate, sort);
 
     if (dataList.size() > 20_000) {
-      log.warn(
-          "지수 데이터 CSV Export 경고: {}건 대량의 데이터가 요청되었습니다 (indexInfoId={}, startDate={}, endDate={})",
-          dataList.size(), indexInfoId, startDate, endDate);
+      log.warn("지수 데이터 CSV Export 경고: {}건 대량의 데이터가 요청되었습니다.", dataList.size());
     }
 
     List<String[]> rows = new ArrayList<>();

--- a/src/main/java/com/kueennevercry/findex/service/IndexDataServiceImpl.java
+++ b/src/main/java/com/kueennevercry/findex/service/IndexDataServiceImpl.java
@@ -11,7 +11,6 @@ import com.kueennevercry.findex.dto.response.RankedIndexPerformanceDto;
 import com.kueennevercry.findex.entity.IndexData;
 import com.kueennevercry.findex.entity.IndexInfo;
 import com.kueennevercry.findex.entity.SourceType;
-import com.kueennevercry.findex.infra.openapi.OpenApiClient;
 import com.kueennevercry.findex.mapper.IndexDataMapper;
 import com.kueennevercry.findex.repository.IndexDataRepository;
 import com.kueennevercry.findex.repository.IndexInfoRepository;
@@ -27,17 +26,16 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class IndexDataServiceImpl implements IndexDataService {
-
-  private final OpenApiClient openApiClient;
-  private String STOCK_INDEX_ENDPOINT = "/getStockMarketIndex";
 
   private final IndexInfoRepository indexInfoRepository;
   private final IndexDataRepository indexDataRepository;
@@ -138,7 +136,6 @@ public class IndexDataServiceImpl implements IndexDataService {
         baseDate, beforeBaseDate, indexInfoId
     );
 
-    // 정렬 + 랭킹 부여
     List<RankedIndexPerformanceDto> sorted = raw.stream()
         .sorted(Comparator.comparing(
             (RankedIndexPerformanceDto dto) -> dto.performance().fluctuationRate()).reversed())
@@ -154,10 +151,8 @@ public class IndexDataServiceImpl implements IndexDataService {
   public List<IndexPerformanceDto> getFavoritePerformances(PeriodType periodType) {
     List<IndexInfo> favorites = indexInfoRepository.findAllByFavoriteTrue();
 
-    LocalDate baseDate = indexDataRepository.findLatestBaseDateAcrossAll();
-    if (baseDate == null) {
-      return List.of();
-    }
+    LocalDate baseDate = indexDataRepository.findMaxBaseDate()
+        .orElseThrow(() -> new IllegalStateException("지수 데이터가 없습니다."));
 
     LocalDate compareDate = calculateStartDate(baseDate, periodType);
 
@@ -195,6 +190,54 @@ public class IndexDataServiceImpl implements IndexDataService {
     }
 
     return results;
+  }
+
+  @Override
+  public List<String[]> getExportableIndexData(Long indexInfoId, LocalDate startDate,
+      LocalDate endDate, Sort sort) {
+    LocalDate now = LocalDate.now();
+
+    if (endDate == null) {
+      endDate = now;
+    }
+
+    if (startDate == null) {
+      startDate = indexDataRepository.findMinBaseDate(indexInfoId)
+          .orElseThrow(() -> new NoSuchElementException("해당 지수의 데이터가 존재하지 않습니다."));
+    }
+
+    List<IndexData> dataList = indexDataRepository.findAllByIndexInfo_IdAndBaseDateBetween(
+        indexInfoId, startDate, endDate, sort);
+
+    if (dataList.size() > 20_000) {
+      log.warn(
+          "지수 데이터 CSV Export 경고: {}건 대량의 데이터가 요청되었습니다 (indexInfoId={}, startDate={}, endDate={})",
+          dataList.size(), indexInfoId, startDate, endDate);
+    }
+
+    List<String[]> rows = new ArrayList<>();
+
+    rows.add(new String[]{
+        "기준일자", "시가", "종가", "고가", "저가",
+        "전일대비등락", "등락률", "거래량", "거래대금", "시가총액"
+    });
+
+    for (IndexData data : dataList) {
+      rows.add(new String[]{
+          data.getBaseDate().toString(),
+          String.valueOf(data.getMarketPrice()),
+          String.valueOf(data.getClosingPrice()),
+          String.valueOf(data.getHighPrice()),
+          String.valueOf(data.getLowPrice()),
+          String.valueOf(data.getVersus()),
+          String.valueOf(data.getFluctuationRate()),
+          String.valueOf(data.getTradingQuantity()),
+          String.valueOf(data.getTradingPrice()),
+          String.valueOf(data.getMarketTotalAmount())
+      });
+    }
+
+    return rows;
   }
 
   private List<ChartDataPoint> calculateMovingAverage(List<ChartDataPoint> points, int windowSize) {


### PR DESCRIPTION
## 📝 변경사항 요약
- 지수 데이터를 CSV 파일로 Export 할 수 있습니다.
- Export할 지수 데이터를 지수 데이터 목록 조회와 같은 규칙으로 필터링 및 정렬할 수 있습니다.
    - 페이지네이션은 고려하지 않습니다.

## 📋 체크리스트
- [x] 지수 데이터를 CSV 파일로 export합니다.
- [x] 지수 정보 ID, 시작 일자, 종료 일자, 정렬 필드, 정렬 방향을 이용해 지수 데이터를 CSV 파일로 export합니다.

## 🔗 관련 이슈
Closes [#18](https://github.com/Kueen-never-cry/sb03-findex-team1/issues/18)

## 💬 추가 설명
지수 데이터 Export 관련

데이터가 비교적 풍부한 지수로 확인했습니다.
- KRX 300 헬스케어
  - StartDate 없이 조회하는 경우
    - 프로토 타입: 2023-01-02 부터 확인됨
    - OpenAPI: 2020-01-02 부터 확인됨

요구사항에 따르면 조회 조건과 동일한 조건으로 다운로드가 가능해야 하기에 제약 없이 다운로드 받을 수 있도록 작업했습니다.

데이터가 많아진다면 제약을 추가하거나 용량이 커서 다운로드 할 수 없다는 경고가 필요할 수도 있을 것 같습니다.
이번엔 20,000건 이상 다운로드 되는 경우에 대해 경고 로그를 남길 수 있도록 작업했습니다.

필요한 경우 이후 추가 수정 작업하겠습니다. 

## 비고

![postman-index-data-export](https://github.com/user-attachments/assets/dedd513a-0913-4e50-99e2-0afe9ca622ff)

![image](https://github.com/user-attachments/assets/d69329e6-b2fb-48c1-902e-a4fad5bb6072)