### PR TITLE
Feature/지수 정보 삭제 #30

### DIFF
--- a/src/main/java/com/kueennevercry/findex/controller/IndexInfoController.java
+++ b/src/main/java/com/kueennevercry/findex/controller/IndexInfoController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.DeleteMapping;
 
 @RestController
 @RequestMapping("/api/index-infos")
@@ -58,5 +59,14 @@ public class IndexInfoController {
 
     IndexInfoDto updatedIndexInfo = indexInfoService.update(id, request);
     return ResponseEntity.ok(updatedIndexInfo);
+  }
+
+  /**
+   * 지수 정보 삭제 DELETE /api/index-infos/{id}
+   */
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteIndexInfo(@PathVariable Long id) {
+    indexInfoService.delete(id);
+    return ResponseEntity.noContent().build(); // HTTP 204 No Content
   }
 }

--- a/src/main/java/com/kueennevercry/findex/repository/AutoSyncConfigRepository.java
+++ b/src/main/java/com/kueennevercry/findex/repository/AutoSyncConfigRepository.java
@@ -15,4 +15,10 @@ public interface AutoSyncConfigRepository extends JpaRepository<AutoSyncConfig, 
 
   @Query("SELECT c FROM AutoSyncConfig c JOIN FETCH c.indexInfo WHERE c.id = :id")
   Optional<AutoSyncConfig> findById(@Param("id") Long id);
+
+  /**
+   * 특정 지수 정보에 연관된 자동 연동 설정 삭제
+   * IndexInfo 삭제 시 연관 데이터 정리용
+   */
+  void deleteByIndexInfo_Id(Long indexInfoId);
 }

--- a/src/main/java/com/kueennevercry/findex/repository/IndexDataRepository.java
+++ b/src/main/java/com/kueennevercry/findex/repository/IndexDataRepository.java
@@ -70,9 +70,14 @@ public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
   List<RankedIndexPerformanceDto> findRankedPerformances(
       @Param("baseDate") LocalDate baseDate,
       @Param("beforeBaseDate") LocalDate beforeBaseDate,
-      @Param("indexInfoId") Long indexInfoId
-  );
+      @Param("indexInfoId") Long indexInfoId);
 
   @Query("SELECT MAX(d.baseDate) FROM IndexData d")
   Optional<LocalDate> findMaxBaseDate();
+
+  /**
+   * 특정 지수 정보에 연관된 모든 지수 데이터 삭제
+   * IndexInfo 삭제 시 연관 데이터 정리용
+   */
+  void deleteAllByIndexInfoId(Long indexInfoId);
 }

--- a/src/test/resources/http/index-infos.http
+++ b/src/test/resources/http/index-infos.http
@@ -25,3 +25,14 @@ Content-Type: application/json
   "baseIndex": 8000,
   "favorite": true
 }
+
+### 지수 정보 삭제 테스트
+
+### 1. 정상 삭제 테스트 (연관 데이터 포함)
+DELETE http://localhost:8080/api/index-infos/187
+
+### 2. 존재하지 않는 ID 삭제 테스트 (에러 발생)
+DELETE http://localhost:8080/api/index-infos/99999
+
+### 3. 삭제 후 조회 테스트 (삭제 확인용)
+GET http://localhost:8080/api/index-infos/187


### PR DESCRIPTION
## 📝 변경사항 요약
기존의 지수 정보를 삭제하기 위한 DELETE API 엔드포인트를 구현했습니다. 삭제 시 연관된 데이터들이 함께 삭제되도록 구현하여 데이터 무결성을 보장합니다.

## 🚀 주요 기능
- **지수 정보 수정 API**: `PATCH /api/index-infos/{id}`
- **지수 정보 삭제 API**: DELETE /api/index-infos/{id}
- **연관 데이터 자동 삭제**: IndexData, AutoSyncConfig 함께 삭제
- **트랜잭션 보장**: @Transactional을 통한 원자적 삭제
- **명시적 제어**: CASCADE 대신 수동 삭제로 안전성 확보


## 📋 구현 체크리스트
- [x] IndexDataRepository 연관 데이터 삭제 메서드 추가
- [x] AutoSyncConfigRepository 연관 설정 삭제 메서드 추가
- [x] IndexInfoService 삭제 비즈니스 로직 구현 (트랜잭션 관리)
- [x] DELETE API Controller 엔드포인트 구현
- [x] HTTP 테스트 케이스 작성 및 검증

## 🌐 API 명세
### Request
```http
DELETE /api/index-infos/{id}
```
### Response: (200 OK)
```http
HTTP/1.1 204 No Content
```

### Response: (200 OK)
```json
{
  "timestamp": "2025-06-11T00:30:00",
  "status": 404,
  "error": "Not Found", 
  "message": "삭제할 지수 정보를 찾을 수 없습니다. ID: 99999"
}
```

## 🧪 테스트
- ✅ 정상 삭제 기능 검증 (연관 데이터 포함)
- ✅ 존재하지 않는 ID 삭제 검증 (404 Not Found)
- ✅ 삭제 후 조회를 통한 삭제 확인
- ✅ 연관 데이터 삭제 확인 (IndexData, AutoSyncConfig)

## 🔗 관련 이슈
Closes #30 지수 정보 삭제

## 💬 추가 설명
금융 데이터의 특성상 CASCADE 대신 명시적 제어 방식을 선택. 
- 민감한 정보를 다루기 때문에 삭제 전 검증과 명확한 제어 필요
- 삭제 가능 여부 검증 고려(예시: 거래 중인 지수인지 확인)
- 에러 처리 및 로깅 가능