### PR TITLE
refactor: #65 buildUrl 수정

### DIFF
--- a/src/main/java/com/kueennevercry/findex/infra/openapi/DefaultOpenApiClient.java
+++ b/src/main/java/com/kueennevercry/findex/infra/openapi/DefaultOpenApiClient.java
@@ -36,33 +36,18 @@ public class DefaultOpenApiClient implements OpenApiClient {
     }
   }
 
-  /* FIXME : 더 좋은 방법이 있지 않을까?  */
   private URI buildUrl(IndexInfoApiRequest indexInfoApiRequest) {
-
-    // 1. 자동 인코딩이 필요한 파라미터를 먼저 빌드
-    String encodedOtherParams = UriComponentsBuilder.newInstance()
+    return UriComponentsBuilder.newInstance()
+        .scheme(properties.getScheme())
+        .host(properties.getHost())
+        .path(properties.getPath())
+        .queryParam("serviceKey", properties.getApiEncodedKey())
         .queryParam("resultType", "json")
         .queryParam("pageNo", indexInfoApiRequest.getPageNo())
         .queryParam("numOfRows", indexInfoApiRequest.getNumOfRows())
         .queryParam("beginBasDt", indexInfoApiRequest.getBeginBasDt())
         .queryParam("endBasDt", indexInfoApiRequest.getEndBasDt())
-        .build()
-        .getQuery();
-
-    // 2. 인코딩하지말고, 인코딩이 되어있는 키 값 그대로 써야하므로 분리
-    String query =
-        "?serviceKey=" + properties.getApiEncodedKey() + "&" + encodedOtherParams;
-
-    // 3. 최종 URI 조립
-    String fullUrl = UriComponentsBuilder.newInstance()
-        .scheme(properties.getScheme())
-        .host(properties.getHost())
-        .path(properties.getPath())
-        .build(false)
-        .toUriString()
-        + query;
-
-    System.out.println("11111 " + "URI.create(fullUrl) = " + URI.create(fullUrl));
-    return URI.create(fullUrl);
+        .build(true)
+        .toUri();
   }
 }


### PR DESCRIPTION
## 📝 변경사항 요약
- OpenAPI 사용하기 위한 UrlBuilder 리팩토링

## 📋 체크리스트
- [x] 기존 동작하는 기능과 동일하게 작동하는지 테스트

## 🔗 관련 이슈
Closes #65

## 💬 추가 설명
`UriComponentsBuilder.build(true)`는 내부적으로 `UriUtils.encodeQueryParam()`을 통해 인코딩을 수행한다고 합니다.

이떄 인코딩 대상 값에 대해 필요한 경우에만 인코딩 한다고 해서 아래 코드로 테스트 해봤을 때 이중 인코딩 없이 정상적으로 동작하는 걸 테스트했습니다.
