### PR TITLE
Fix/연동 이력 테이블 외래키(index_info_id) 엔티티 변경

### DIFF
--- a/src/main/java/com/kueennevercry/findex/entity/IntegrationTask.java
+++ b/src/main/java/com/kueennevercry/findex/entity/IntegrationTask.java
@@ -57,7 +57,7 @@ public class IntegrationTask {
   private Instant createdAt;
 
   @ManyToOne
-  @JoinColumn(name = "index_info_id", nullable = false)
+  @JoinColumn(name = "index_info_id")
   private IndexInfo indexInfo;
 
   @PrePersist // 데이터 생성 시 자동으로 실행


### PR DESCRIPTION
## 📝 변경사항 요약
연동 이력 테이블 외래키(index_info_id)를 null 허용 관련해서 엔티티 변경 사항입니다. 

## 📋 체크리스트


## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크(커밋 해시)를 걸어주세요 -->
https://github.com/Kueen-never-cry/sb03-findex-team1/pull/72

## 💬 추가 설명
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
