### PR TITLE
Feature/지수 정보 연동 추가기능

### DIFF
--- a/src/main/java/com/kueennevercry/findex/controller/SyncJobController.java
+++ b/src/main/java/com/kueennevercry/findex/controller/SyncJobController.java
@@ -5,9 +5,11 @@ import com.kueennevercry.findex.dto.SyncJobDto;
 import com.kueennevercry.findex.dto.request.IndexDataSyncRequest;
 import com.kueennevercry.findex.dto.request.SyncJobParameterRequest;
 import com.kueennevercry.findex.service.SyncJobService;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,8 +29,9 @@ public class SyncJobController {
   : Open API를 통해 지수 정보를 연동합니다
    */
   @PostMapping("/index-infos")
-  public List<SyncJobDto> syncIndexInfo() {
-    return this.syncJobService.syncIndexInfo();
+  public ResponseEntity<List<SyncJobDto>> syncIndexInfo(HttpServletRequest request) {
+    String clientIp = this.getClientIp(request);
+    return ResponseEntity.ok(this.syncJobService.syncIndexInfo(clientIp));
   }
 
   /*
@@ -45,10 +48,27 @@ public class SyncJobController {
   연동 작업 목록 조회
   */
   @GetMapping
-  public CursorPageResponseSyncJobDto findAll(
+  public ResponseEntity<CursorPageResponseSyncJobDto> findAll(
       SyncJobParameterRequest syncJobParameterRequest) {
-    return this.syncJobService.findAllByParameters(
-        syncJobParameterRequest);
+    return ResponseEntity.ok(this.syncJobService.findAllByParameters(
+        syncJobParameterRequest));
+
+  }
+
+  private String getClientIp(HttpServletRequest request) {
+    String ip = request.getHeader("X-Forwarded-For");
+    if (ip != null && !ip.isEmpty() && !"unknown".equalsIgnoreCase(ip)) {
+      return ip.split(",")[0];
+    }
+    ip = request.getHeader("Proxy-Client-IP");
+    if (ip != null && !ip.isEmpty() && !"unknown".equalsIgnoreCase(ip)) {
+      return ip;
+    }
+    ip = request.getHeader("WL-Proxy-Client-IP");
+    if (ip != null && !ip.isEmpty() && !"unknown".equalsIgnoreCase(ip)) {
+      return ip;
+    }
+    return request.getRemoteAddr();
   }
 
 }

--- a/src/main/java/com/kueennevercry/findex/infra/openapi/DefaultOpenApiClient.java
+++ b/src/main/java/com/kueennevercry/findex/infra/openapi/DefaultOpenApiClient.java
@@ -84,8 +84,9 @@ public class DefaultOpenApiClient implements OpenApiClient {
   }
 
   private URI buildUrl(IndexInfoApiRequest indexInfoApiRequest) {
-    String encodedIdxNm = URLEncoder.encode(indexInfoApiRequest.getIdxNm(), StandardCharsets.UTF_8)
-        .replace("+", "%20");  // 공백 -> + -> %20으로 치환
+    String encodedIdxNm = indexInfoApiRequest.getIdxNm() == null ? null
+        : URLEncoder.encode(indexInfoApiRequest.getIdxNm(), StandardCharsets.UTF_8)
+            .replace("+", "%20");  // 공백 -> + -> %20으로 치환
 
     return UriComponentsBuilder.newInstance()
         .scheme(properties.getScheme())

--- a/src/main/java/com/kueennevercry/findex/service/SyncJobService.java
+++ b/src/main/java/com/kueennevercry/findex/service/SyncJobService.java
@@ -17,6 +17,7 @@ import com.kueennevercry.findex.repository.IntegrationTaskRepository;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,40 +30,105 @@ public class SyncJobService {
   private final IndexInfoRepository indexInfoRepository;
   private final IntegrationTaskMapper integrationTaskMapper;
   private final OpenApiClient openApiClient;
+  private String clientIp = null;
 
   public CursorPageResponseSyncJobDto findAllByParameters(
       SyncJobParameterRequest syncJobParameterRequest) {
-
     return integrationTaskRepository.findAllByParameters(syncJobParameterRequest);
   }
 
-  public List<SyncJobDto> syncIndexInfo() {
-    IndexInfoApiRequest apiRequestParams = IndexInfoApiRequest.builder().numOfRows(500).pageNo(1)
-        .basDt("20250610") // 하루치 데이터를 기준으로 지수정보 카테고리화
-        .build();
+  public List<SyncJobDto> syncIndexInfo(String clientIp) {
 
-    // 1. 순수 openApi에서 가져온  데이터
-    List<IndexInfoApiResponse> indexDataList = openApiClient.fetchAllIndexData(apiRequestParams);
+    this.clientIp = clientIp;
 
-    //2. indexInfo에 이미 데이터 있으면 바로 integrationTask 데이터 삽입, 없으면 indexInfo 데이터 생성 후 integrationTask 데이터 삽입
+    // 1. openApi에서 가져온 외부 데이터
+    List<IndexInfoApiResponse> openApiDataList = this.fetchIndexInfoFromOpenApi();
     List<IntegrationTask> integrationTaskList = new ArrayList<>();
-    indexDataList.forEach(indexInfoFromApi -> {
-      Optional<IndexInfo> indexInfo = indexInfoRepository.findByIndexNameAndIndexClassification(
-          indexInfoFromApi.indexName(), indexInfoFromApi.indexClassification());
-      if (indexInfo.isPresent()) {
-        integrationTaskList.add(this.buildIntegrationTaskEntity(indexInfo.get()));
-      } else {
-        IndexInfo createdIndexInfo = this.createIndexInfo(indexInfoFromApi);
-        integrationTaskList.add(this.buildIntegrationTaskEntity(createdIndexInfo));
-      }
-    });
-    List<IntegrationTask> createdIntegrationTaskList = this.createIntegrationTasks(
-        integrationTaskList);
 
-    return createdIntegrationTaskList.stream().map(integrationTaskMapper::toSyncJobDto).toList();
+    //2. indexInfo 생성 or 조회
+    for (IndexInfoApiResponse indexInfoFromApi : openApiDataList) {
+      IndexInfo indexInfo = null;
+      try {
+        // DB에서 있는 데이터 가져와서 다르면 업데이트, 없으면 DB에 생성해서 가져옴
+        Optional<IndexInfo> optional = indexInfoRepository.findByIndexNameAndIndexClassification(
+            indexInfoFromApi.indexName(), indexInfoFromApi.indexClassification());
+        if (optional.isPresent()) {
+          indexInfo = optional.get();
+          this.updateIndexInfo(indexInfo, indexInfoFromApi);
+        } else {
+          indexInfo = this.saveIndexInfo(indexInfoFromApi);
+        }
+
+        integrationTaskList.add(
+            this.buildIntegrationTaskEntity(indexInfo, IntegrationResultType.SUCCESS)
+        );
+      } catch (Exception e) {
+        // 실패해도, integration task 데이터 넣음
+        integrationTaskList.add(
+            this.buildIntegrationTaskEntity(indexInfo, IntegrationResultType.FAILED)
+        );
+      }
+    }
+
+    // 3. integrationTask DB 저장
+    return this.saveIntegrationTasks(integrationTaskList)
+        .stream()
+        .map(integrationTaskMapper::toSyncJobDto)
+        .toList();
   }
 
-  private IndexInfo createIndexInfo(IndexInfoApiResponse indexInfoFromApi) {
+  private void updateIndexInfo(IndexInfo existed, IndexInfoApiResponse indexInfoFromApi) {
+
+    boolean updated = false;
+    if (!Objects.equals(existed.getEmployedItemsCount(), indexInfoFromApi.employedItemsCount())) {
+      existed.setEmployedItemsCount(indexInfoFromApi.employedItemsCount());
+      updated = true;
+    }
+    if (!Objects.equals(existed.getBasePointInTime(), indexInfoFromApi.basePointInTime())) {
+      existed.setBasePointInTime(indexInfoFromApi.basePointInTime());
+      updated = true;
+    }
+    if (!Objects.equals(existed.getBaseIndex(), indexInfoFromApi.baseIndex())) {
+      existed.setBaseIndex(indexInfoFromApi.baseIndex());
+      updated = true;
+    }
+    if (!existed.getSourceType().equals(SourceType.OPEN_API)) {
+      existed.setSourceType(SourceType.OPEN_API);
+      updated = true;
+    }
+    if (updated) {
+      indexInfoRepository.save(existed);
+      indexInfoRepository.flush();
+    }
+  }
+
+  private List<IndexInfoApiResponse> fetchIndexInfoFromOpenApi() {
+    try {
+      IndexInfoApiRequest apiRequestParams = IndexInfoApiRequest.builder().numOfRows(500).pageNo(1)
+          .basDt("20250610") // 하루치 데이터를 기준으로 지수정보 카테고리화
+          .build();
+      return openApiClient.fetchAllIndexData(apiRequestParams);
+    } catch (Exception e) {
+      IntegrationTask createdIntegrationTask = this.buildIntegrationTaskEntity(null,
+          IntegrationResultType.FAILED);
+      this.saveIntegrationTasks(List.of(createdIntegrationTask));
+      throw new RuntimeException("OPEN Api의 데이터를 가져올 수 없습니다.");
+    }
+  }
+
+  private IntegrationTask buildIntegrationTaskEntity(IndexInfo indexInfo,
+      IntegrationResultType resultType) {
+    return IntegrationTask.builder()
+        .jobType(IntegrationJobType.INDEX_INFO)
+        .targetDate(null)
+        .worker(this.clientIp == null ? "SYSTEM" : this.clientIp)
+        .jobTime(Instant.now())
+        .result(resultType)
+        .indexInfo(indexInfo)
+        .build();
+  }
+
+  private IndexInfo saveIndexInfo(IndexInfoApiResponse indexInfoFromApi) {
     IndexInfo newIndexInfo = IndexInfo.builder()
         .indexClassification(indexInfoFromApi.indexClassification())
         .indexName(indexInfoFromApi.indexName())
@@ -74,19 +140,8 @@ public class SyncJobService {
     return indexInfoRepository.save(newIndexInfo);
   }
 
-  private IntegrationTask buildIntegrationTaskEntity(IndexInfo indexInfo) {
-    return IntegrationTask.builder()
-        .jobType(IntegrationJobType.INDEX_INFO)
-        .targetDate(null)
-        .worker(SourceType.OPEN_API.name())
-        .jobTime(Instant.now())
-        .result(IntegrationResultType.SUCCESS)  // TODO : success를 default로 두는게 맞나? -> 추후 수정
-        .indexInfo(indexInfo)
-        .build();
-  }
-
-  private List<IntegrationTask> createIntegrationTasks(List<IntegrationTask> integrationTaskList) {
-    return integrationTaskRepository.saveAll(integrationTaskList);
+  private List<IntegrationTask> saveIntegrationTasks(List<IntegrationTask> integrationTaskList) {
+    return integrationTaskRepository.saveAllAndFlush(integrationTaskList);
   }
 
 }


### PR DESCRIPTION
## 📝 변경사항 요약
- `syncIndexInfo` 메서드가 여러 책임을 가지고 있어 각각 하나의 책임만 갖을 수 있도록 메서드 분리 & 리팩토링
- `integrationTasks` 테이블 `worker` 컬럼에 client IP 삽입
-  연동 중 예외 발생 하는 경우에 `integrationTasks` 테이블에 실패 기록 남김
- 기존에 있던 `지수 정보`와 연동해서 가지고 온 `지수 정보`를 비교해서 정보가 업데이트 됐다면, 데이터도 업데이트


## 📋 체크리스트
- [x] 로컬 테스트 완료

## 🔗 관련 이슈
#19 

## 💬 추가 설명
+ 트랜잭션을 넣으려고 했으나, 예외가 발생한 상황에 rollback이 되는게 아닌,  `integrationTasks` 테이블에 실패 기록을 남겨야 하므로 트랜잭션 사용 안했습니다. 

더 좋은 의견 있으면 남겨주세요!