### PR TITLE
Feature/지수 데이터 연동

### DIFF
--- a/src/main/java/com/kueennevercry/findex/controller/SyncJobController.java
+++ b/src/main/java/com/kueennevercry/findex/controller/SyncJobController.java
@@ -5,6 +5,7 @@ import com.kueennevercry.findex.dto.SyncJobDto;
 import com.kueennevercry.findex.dto.request.IndexDataSyncRequest;
 import com.kueennevercry.findex.dto.request.SyncJobParameterRequest;
 import com.kueennevercry.findex.service.SyncJobService;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,9 +37,8 @@ public class SyncJobController {
   : Open API를 통해 지수 데이터를 연동합니다
  */
   @PostMapping("/index-data")
-  public SyncJobDto syncIndexData(@RequestBody IndexDataSyncRequest indexDataSyncRequest) {
-    //XXX : 구조만 잡아놓음
-    return null;
+  public List<SyncJobDto> syncIndexData(@RequestBody @Valid IndexDataSyncRequest request) {
+    return this.syncJobService.syncIndexData(request);
   }
 
   /*

--- a/src/main/java/com/kueennevercry/findex/dto/request/IndexDataSyncRequest.java
+++ b/src/main/java/com/kueennevercry/findex/dto/request/IndexDataSyncRequest.java
@@ -4,9 +4,10 @@ import java.time.LocalDate;
 import java.util.List;
 
 /* 지수 데이터 연동 요청 */
-public class IndexDataSyncRequest {
+public record IndexDataSyncRequest(
+    List<Long> indexInfoIds,
+    LocalDate baseDateFrom,
+    LocalDate baseDateTo
+) {
 
-  List<Long> indexInfoIds;
-  LocalDate baseDateFrom;
-  LocalDate baseDateTo;
 }

--- a/src/main/java/com/kueennevercry/findex/dto/request/IndexInfoApiRequest.java
+++ b/src/main/java/com/kueennevercry/findex/dto/request/IndexInfoApiRequest.java
@@ -13,6 +13,8 @@ public class IndexInfoApiRequest {
 
   private int numOfRows; // 한 페이지 결과 수
 
+  private String idxNm; // 검색값과 지수명이 일치하는 데이터를 검색
+
   private String basDt; // 검색값과 기준일자가 일치하는 데이터를 검색 ex)20250610
 
   private String beginBasDt; // 기준일자가 검색값보다 크거나 같은 데이터를 검색

--- a/src/main/java/com/kueennevercry/findex/infra/openapi/OpenApiClient.java
+++ b/src/main/java/com/kueennevercry/findex/infra/openapi/OpenApiClient.java
@@ -7,4 +7,7 @@ import java.util.List;
 public interface OpenApiClient {
 
   List<IndexInfoApiResponse> fetchAllIndexData(IndexInfoApiRequest indexInfoApiRequest);
+
+  List<IndexInfoApiResponse> fetchAllIndexDataByNameAndDateRange(String indexName, String beginDate,
+      String endDate);
 }

--- a/src/main/java/com/kueennevercry/findex/mapper/IndexDataMapper.java
+++ b/src/main/java/com/kueennevercry/findex/mapper/IndexDataMapper.java
@@ -2,10 +2,13 @@ package com.kueennevercry.findex.mapper;
 
 import com.kueennevercry.findex.dto.response.CursorPageResponse;
 import com.kueennevercry.findex.dto.response.IndexDataDto;
+import com.kueennevercry.findex.dto.response.IndexInfoApiResponse;
 import com.kueennevercry.findex.entity.IndexData;
+import com.kueennevercry.findex.entity.IndexInfo;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,6 +17,21 @@ public interface IndexDataMapper {
 
   @Mapping(source = "indexInfo.id", target = "indexInfoId")
   IndexDataDto toDto(IndexData indexData);
+
+  void updateEntity(IndexInfoApiResponse response, @MappingTarget IndexData target);
+
+  @Mapping(source = "response.baseDate", target = "baseDate")
+  @Mapping(source = "response.marketPrice", target = "marketPrice")
+  @Mapping(source = "response.closingPrice", target = "closingPrice")
+  @Mapping(source = "response.highPrice", target = "highPrice")
+  @Mapping(source = "response.lowPrice", target = "lowPrice")
+  @Mapping(source = "response.versus", target = "versus")
+  @Mapping(source = "response.fluctuationRate", target = "fluctuationRate")
+  @Mapping(source = "response.tradingQuantity", target = "tradingQuantity")
+  @Mapping(source = "response.tradingPrice", target = "tradingPrice")
+  @Mapping(source = "response.marketTotalAmount", target = "marketTotalAmount")
+  @Mapping(source = "indexInfo", target = "indexInfo")
+  IndexData toEntity(IndexInfoApiResponse response, IndexInfo indexInfo);
 
   default CursorPageResponse<IndexDataDto> toCursorDto(
       List<IndexDataDto> content,
@@ -31,6 +49,4 @@ public interface IndexDataMapper {
         totalElements,
         hasNext);
   }
-
-  ;
 }

--- a/src/main/java/com/kueennevercry/findex/repository/IndexDataRepository.java
+++ b/src/main/java/com/kueennevercry/findex/repository/IndexDataRepository.java
@@ -36,7 +36,7 @@ public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
   Optional<LocalDate> findMinBaseDateByIndexIfoId(@Param("indexInfoId") Long indexInfoId);
 
   @Query("SELECT MAX(d.baseDate) FROM IndexData d WHERE d.indexInfo.id = :indexInfoId")
-  Optional<LocalDate> findLatestBaseDateByIndexInfoId(@Param("indexInfoId") Long indexInfoId);
+  Optional<LocalDate> findMaxBaseDateByIndexInfoId(@Param("indexInfoId") Long indexInfoId);
 
   @Query("SELECT d FROM IndexData d WHERE d.indexInfo.id = :indexInfoId AND d.baseDate = :baseDate")
   Optional<IndexData> findByIndexInfoIdAndBaseDate(Long indexInfoId, LocalDate baseDate);

--- a/src/main/java/com/kueennevercry/findex/service/IndexDataServiceImpl.java
+++ b/src/main/java/com/kueennevercry/findex/service/IndexDataServiceImpl.java
@@ -116,7 +116,7 @@ public class IndexDataServiceImpl implements IndexDataService {
     IndexInfo indexInfo = indexInfoRepository.findById(indexInfoId)
         .orElseThrow(() -> new IllegalStateException("지수 정보가 없습니다."));
 
-    LocalDate endDate = indexDataRepository.findLatestBaseDateByIndexInfoId(indexInfoId)
+    LocalDate endDate = indexDataRepository.findMaxBaseDateByIndexInfoId(indexInfoId)
         .orElseThrow(() -> new IllegalStateException("지수 데이터가 없습니다."));
     LocalDate startDate = calculateStartDate(endDate, periodType);
 

--- a/src/main/java/com/kueennevercry/findex/service/SyncJobService.java
+++ b/src/main/java/com/kueennevercry/findex/service/SyncJobService.java
@@ -2,22 +2,29 @@ package com.kueennevercry.findex.service;
 
 import com.kueennevercry.findex.dto.CursorPageResponseSyncJobDto;
 import com.kueennevercry.findex.dto.SyncJobDto;
+import com.kueennevercry.findex.dto.request.IndexDataSyncRequest;
 import com.kueennevercry.findex.dto.request.IndexInfoApiRequest;
 import com.kueennevercry.findex.dto.request.SyncJobParameterRequest;
 import com.kueennevercry.findex.dto.response.IndexInfoApiResponse;
+import com.kueennevercry.findex.entity.IndexData;
 import com.kueennevercry.findex.entity.IndexInfo;
 import com.kueennevercry.findex.entity.IntegrationJobType;
 import com.kueennevercry.findex.entity.IntegrationResultType;
 import com.kueennevercry.findex.entity.IntegrationTask;
 import com.kueennevercry.findex.entity.SourceType;
 import com.kueennevercry.findex.infra.openapi.OpenApiClient;
+import com.kueennevercry.findex.mapper.IndexDataMapper;
 import com.kueennevercry.findex.mapper.IntegrationTaskMapper;
+import com.kueennevercry.findex.repository.IndexDataRepository;
 import com.kueennevercry.findex.repository.IndexInfoRepository;
 import com.kueennevercry.findex.repository.IntegrationTaskRepository;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -27,8 +34,11 @@ public class SyncJobService {
 
   private final IntegrationTaskRepository integrationTaskRepository;
   private final IndexInfoRepository indexInfoRepository;
+  private final IndexDataRepository indexDataRepository;
   private final IntegrationTaskMapper integrationTaskMapper;
   private final OpenApiClient openApiClient;
+
+  private final IndexDataMapper indexDataMapper;
 
   public CursorPageResponseSyncJobDto findAllByParameters(
       SyncJobParameterRequest syncJobParameterRequest) {
@@ -62,6 +72,84 @@ public class SyncJobService {
     return createdIntegrationTaskList.stream().map(integrationTaskMapper::toSyncJobDto).toList();
   }
 
+  // 성공한 것과 실패한 것 모두 기록할 수 있게 Transactional 보단 try-catch + save 패턴으로 사용
+  public List<SyncJobDto> syncIndexData(IndexDataSyncRequest request) {
+    LocalDate from = request.baseDateFrom();
+    LocalDate to = request.baseDateTo();
+
+    List<IndexInfo> indexInfos = Optional.ofNullable(request.indexInfoIds())
+        .map(indexInfoRepository::findAllById)
+        .orElseGet(indexInfoRepository::findAll);
+
+    List<IntegrationTask> integrationTasks = new ArrayList<>();
+
+    for (IndexInfo indexInfo : indexInfos) {
+      try {
+        List<IndexInfoApiResponse> responses = openApiClient
+            .fetchAllIndexDataByNameAndDateRange(indexInfo.getIndexName(), from.toString(),
+                to.toString());
+
+        // 날짜별로 그룹화
+        Map<LocalDate, List<IndexInfoApiResponse>> byDate =
+            responses.stream().collect(Collectors.groupingBy(IndexInfoApiResponse::baseDate));
+
+        for (LocalDate date = from; !date.isAfter(to); date = date.plusDays(1)) {
+          List<IndexInfoApiResponse> daily = byDate.getOrDefault(date, List.of());
+
+          try {
+            if (daily.isEmpty()) {
+              // 응답은 있었지만 해당 날짜에 데이터가 없는 경우 성공으로 처리
+              integrationTasks.add(
+                  buildIntegrationTaskEntity(indexInfo, date, IntegrationJobType.INDEX_DATA,
+                      IntegrationResultType.SUCCESS));
+            } else {
+              // 성공
+              for (IndexInfoApiResponse response : daily) {
+                upsertIndexData(indexInfo, response);
+              }
+              integrationTasks.add(
+                  buildIntegrationTaskEntity(indexInfo, date, IntegrationJobType.INDEX_DATA,
+                      IntegrationResultType.SUCCESS));
+            }
+          } catch (Exception e) {
+            // 내부적인 오류로 실패
+            integrationTasks.add(
+                buildIntegrationTaskEntity(indexInfo, date, IntegrationJobType.INDEX_DATA,
+                    IntegrationResultType.FAILED));
+          }
+        }
+
+      } catch (Exception e) {
+        // 통신 실패 또는 전체 응답 처리 실패 시 해당 범위 모든 날짜를 실패 처리
+        for (LocalDate date = from; !date.isAfter(to); date = date.plusDays(1)) {
+          integrationTasks.add(
+              buildIntegrationTaskEntity(indexInfo, date, IntegrationJobType.INDEX_DATA,
+                  IntegrationResultType.FAILED));
+        }
+      }
+    }
+
+    return integrationTaskRepository.saveAll(integrationTasks).stream()
+        .map(integrationTaskMapper::toSyncJobDto)
+        .toList();
+  }
+
+
+  private void upsertIndexData(IndexInfo indexInfo, IndexInfoApiResponse response) {
+    Optional<IndexData> existing = indexDataRepository.findByIndexInfoIdAndBaseDate(
+        indexInfo.getId(), response.baseDate());
+
+    if (existing.isPresent()) {
+      IndexData data = existing.get();
+      data.setIndexInfo(indexInfo); // 수동 지정
+      indexDataMapper.updateEntity(response, data);
+      indexDataRepository.save(data);
+    } else {
+      IndexData newData = indexDataMapper.toEntity(response, indexInfo);
+      indexDataRepository.save(newData);
+    }
+  }
+
   private IndexInfo createIndexInfo(IndexInfoApiResponse indexInfoFromApi) {
     IndexInfo newIndexInfo = IndexInfo.builder()
         .indexClassification(indexInfoFromApi.indexClassification())
@@ -85,8 +173,24 @@ public class SyncJobService {
         .build();
   }
 
+  // TODO : 가능하면 지수 정보, 지수 데이터 통합하여 사용
+  private IntegrationTask buildIntegrationTaskEntity(
+      IndexInfo indexInfo,
+      LocalDate date,
+      IntegrationJobType type,
+      IntegrationResultType result
+  ) {
+    return IntegrationTask.builder()
+        .jobType(type)
+        .targetDate(date)
+        .worker(SourceType.OPEN_API.name())
+        .jobTime(Instant.now())
+        .result(result)
+        .indexInfo(indexInfo)
+        .build();
+  }
+
   private List<IntegrationTask> createIntegrationTasks(List<IntegrationTask> integrationTaskList) {
     return integrationTaskRepository.saveAll(integrationTaskList);
   }
-
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,11 +32,7 @@ springdoc:
     operations-sorter: method
 
 # Open API
-# 개발 환경: Run > Edit Configurations > Environment variables에 `OPEN_API_KEY=발급 받은 키`를 등록합니다.
-# 운영 환경: OS 환경 변수 등록 또는 dotenv-spring-boot 외부 라이브러리를 고려합니다.
 openapi:
-  base-url: https://apis.data.go.kr/1160100/service/GetMarketIndexInfoService
-  api-key: ${OPEN_API_KEY}
   api-encoded-key: ${OPEN_API_ENCODED_KEY}
   scheme: "https"
   host: "apis.data.go.kr"


### PR DESCRIPTION
## 📝 변경사항 요약
- Open API를 활용해 지수 데이터를 등록, 수정할 수 있습니다.
- **{지수}, {대상 날짜}** 로 연동할 데이터의 범위를 지정할 수 있습니다.
    - **{대상 날짜}** 는 반드시 지정해야하며, 범위로 지정할 수 있습니다.
    - **{지수}** 는 선택적으로 지정할 수 있습니다.
- 지수 데이터 연동은 사용자가 직접 실행할 수 있습니다.
    - 실행 후 연동 작업 결과를 등록합니다.
    - 대상 지수, 대상 날짜가 여러 개인 경우 지수, 날짜 별로 이력을 등록합니다.

## 📋 체크리스트

아래 항목은 프론트 코드에 의해 동작한다면 정상적으로 동작할 것 같습니다.
이후 이슈 발생 시 이슈 PR로 빠르게 처리하겠습니다.

- [x]  1 . 'Open API 연동 ' 클릭 시 Open API의 데이터를 가져와 DB 저장
- [x]  2. 연동 완료 후 신규/업데이트/변동없음 건수 UI에 표시
- [x]  3. 연동 완료 후 '지수 관리' 뷰에 연동된 데이터 로드 

## 🔗 관련 이슈
Closes #20 

## 💬 추가 설명
- 정상적인 요청이며 해당 범위 내에서 조회를 성공했고 그저 데이터가 없는 경우라면 성공으로 처리한다.
    - 그 외 오류에 대해선 실패로 처리한다.
- 지수 데이터를 삽입하는 도중 알 수 없는 원인으로 중간에 실패하게 된다면 요청했던 범위의 연동 이력을 실패로 기록한다.
    - 그렇지 않다면 협의가 필요하다. 성공적인 요청 건에 대해선 성공 이력을 남기면서 중간에 끊긴 알 수 없는 원인에 대한 것만 실패로 기록할 수 있는 방안을 모색해야 한다.

## 비고
![sync-index-data](https://github.com/user-attachments/assets/c5795b19-413b-48c9-98a5-7e34b68d9ab1)