### PR TITLE
fix/ 자동 연동 작업시 worker 값 오류 

### DIFF
--- a/src/main/java/com/kueennevercry/findex/service/RealIndexSyncService.java
+++ b/src/main/java/com/kueennevercry/findex/service/RealIndexSyncService.java
@@ -17,6 +17,6 @@ public class RealIndexSyncService implements IndexSyncService {
   @Override
   public void sync(Long indexInfoId, LocalDate from, LocalDate to) {
     IndexDataSyncRequest request = new IndexDataSyncRequest(List.of(indexInfoId), from, to);
-    syncJobService.syncIndexData(request);
+    syncJobService.syncIndexData(request, "SYSTEM");
   }
 }


### PR DESCRIPTION
## 📝 변경사항 요약
자동 연동 작업시 worker 값 'SYSTEM' 을 기본값으로 넣음 

## 📋 체크리스트
- [ ] 
- [ ] 
- [ ] 
- [ ] 

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크(커밋 해시)를 걸어주세요 -->

## 💬 추가 설명
 통합 테스트 할때 나온 이슈입니다. 
