### PR TITLE
Fix/자동 연동 지수 목록

### DIFF
--- a/src/main/java/com/kueennevercry/findex/dto/response/AutoSyncConfigDto.java
+++ b/src/main/java/com/kueennevercry/findex/dto/response/AutoSyncConfigDto.java
@@ -3,8 +3,8 @@ package com.kueennevercry.findex.dto.response;
 public record AutoSyncConfigDto(
     Long id,
     Long indexInfoId,
-    String indexClassification,
     String indexName,
+    String indexClassification,
     Boolean enabled
 ) {
 

--- a/src/main/java/com/kueennevercry/findex/repository/AutoSyncConfigCustomRepositoryImpl.java
+++ b/src/main/java/com/kueennevercry/findex/repository/AutoSyncConfigCustomRepositoryImpl.java
@@ -2,9 +2,9 @@ package com.kueennevercry.findex.repository;
 
 import com.kueennevercry.findex.dto.response.AutoSyncConfigDto;
 import com.kueennevercry.findex.dto.response.CursorPageResponse;
-import com.kueennevercry.findex.entity.AutoSyncConfig;
 import com.kueennevercry.findex.entity.QAutoSyncConfig;
 import com.kueennevercry.findex.entity.QIndexInfo;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -32,23 +32,30 @@ public class AutoSyncConfigCustomRepositoryImpl implements AutoSyncConfigCustomR
     QIndexInfo index = QIndexInfo.indexInfo;
 
     var query = queryFactory
-        .selectFrom(config)
-        .leftJoin(config.indexInfo, index).fetchJoin()
+        .select(Projections.constructor(AutoSyncConfigDto.class,
+            config.id,
+            index.id,
+            index.indexName,
+            index.indexClassification,
+            config.enabled.coalesce(false)
+        ))
+        .from(index)
+        .leftJoin(config).on(config.indexInfo.id.eq(index.id))
         .where(
             indexInfoIdEq(indexInfoId, index),
             enabledEq(enabled, config),
-            idAfterGt(idAfter, config)
+            idAfterGt(idAfter, index)
         );
 
     if ("enabled".equals(sortField)) {
       query.orderBy("desc".equals(sortDirection) ? config.enabled.desc() : config.enabled.asc());
     } else if ("id".equals(sortField)) {
-      query.orderBy("desc".equals(sortDirection) ? config.id.desc() : config.id.asc());
+      query.orderBy("desc".equals(sortDirection) ? index.id.desc() : index.id.asc());
     } else {
       query.orderBy("desc".equals(sortDirection) ? index.indexName.desc() : index.indexName.asc());
     }
 
-    List<AutoSyncConfig> results = query
+    List<AutoSyncConfigDto> results = query
         .limit(size + 1)
         .fetch();
 
@@ -57,31 +64,17 @@ public class AutoSyncConfigCustomRepositoryImpl implements AutoSyncConfigCustomR
       results.remove(size);
     }
 
-    List<AutoSyncConfigDto> dtoList = results.stream()
-        .map(cfg -> new AutoSyncConfigDto(
-            cfg.getId(),
-            cfg.getIndexInfo().getId(),
-            cfg.getIndexInfo().getIndexName(),
-            cfg.getIndexInfo().getIndexClassification(),
-            cfg.isEnabled()
-        ))
-        .toList();
-
-    Long nextIdAfter = dtoList.isEmpty() ? null : dtoList.get(dtoList.size() - 1).id();
+    Long nextIdAfter = results.isEmpty() ? null : results.get(results.size() - 1).indexInfoId();
 
     Long countResult = queryFactory
-        .select(config.count())
-        .from(config)
-        .leftJoin(config.indexInfo, index)
-        .where(
-            indexInfoIdEq(indexInfoId, index),
-            enabledEq(enabled, config)
-        )
+        .select(index.count())
+        .from(index)
+        .where(indexInfoIdEq(indexInfoId, index))
         .fetchOne();
 
     long totalElements = countResult != null ? countResult : 0L;
 
-    return new CursorPageResponse<>(dtoList, null, nextIdAfter, size, totalElements, hasNext);
+    return new CursorPageResponse<>(results, null, nextIdAfter, size, totalElements, hasNext);
   }
 
   private BooleanExpression indexInfoIdEq(Long indexInfoId, QIndexInfo index) {
@@ -92,7 +85,7 @@ public class AutoSyncConfigCustomRepositoryImpl implements AutoSyncConfigCustomR
     return enabled != null ? config.enabled.eq(enabled) : null;
   }
 
-  private BooleanExpression idAfterGt(Long idAfter, QAutoSyncConfig config) {
-    return idAfter != null ? config.id.gt(idAfter) : null;
+  private BooleanExpression idAfterGt(Long idAfter, QIndexInfo index) {
+    return idAfter != null ? index.id.gt(idAfter) : null;
   }
 }

--- a/src/main/java/com/kueennevercry/findex/repository/AutoSyncConfigCustomRepositoryImpl.java
+++ b/src/main/java/com/kueennevercry/findex/repository/AutoSyncConfigCustomRepositoryImpl.java
@@ -37,10 +37,10 @@ public class AutoSyncConfigCustomRepositoryImpl implements AutoSyncConfigCustomR
             index.id,
             index.indexName,
             index.indexClassification,
-            config.enabled.coalesce(false)
+            config.enabled
         ))
-        .from(index)
-        .leftJoin(config).on(config.indexInfo.id.eq(index.id))
+        .from(config)
+        .join(config.indexInfo, index)
         .where(
             indexInfoIdEq(indexInfoId, index),
             enabledEq(enabled, config),
@@ -67,8 +67,9 @@ public class AutoSyncConfigCustomRepositoryImpl implements AutoSyncConfigCustomR
     Long nextIdAfter = results.isEmpty() ? null : results.get(results.size() - 1).indexInfoId();
 
     Long countResult = queryFactory
-        .select(index.count())
-        .from(index)
+        .select(config.count())
+        .from(config)
+        .join(config.indexInfo, index)
         .where(indexInfoIdEq(indexInfoId, index))
         .fetchOne();
 

--- a/src/main/java/com/kueennevercry/findex/repository/AutoSyncConfigRepository.java
+++ b/src/main/java/com/kueennevercry/findex/repository/AutoSyncConfigRepository.java
@@ -11,17 +11,18 @@ import org.springframework.data.repository.query.Param;
 public interface AutoSyncConfigRepository extends JpaRepository<AutoSyncConfig, Long>,
     AutoSyncConfigCustomRepository {
 
-  boolean existsByIndexInfo(IndexInfo indexInfo);
+  boolean existsByIndexInfo_Id(Long indexInfoId);
 
   Optional<AutoSyncConfig> findByIndexInfo(IndexInfo indexInfo);
 
   @Query("SELECT c FROM AutoSyncConfig c JOIN FETCH c.indexInfo WHERE c.id = :id")
   Optional<AutoSyncConfig> findById(@Param("id") Long id);
-  
+
+  @Query("SELECT c FROM AutoSyncConfig c JOIN FETCH c.indexInfo WHERE c.enabled = true")
   List<AutoSyncConfig> findAllByEnabledTrue();
+
   /**
-   * 특정 지수 정보에 연관된 자동 연동 설정 삭제
-   * IndexInfo 삭제 시 연관 데이터 정리용
+   * 특정 지수 정보에 연관된 자동 연동 설정 삭제 IndexInfo 삭제 시 연관 데이터 정리용
    */
   void deleteByIndexInfo_Id(Long indexInfoId);
 }

--- a/src/main/java/com/kueennevercry/findex/scheduler/IndexAutoSyncScheduler.java
+++ b/src/main/java/com/kueennevercry/findex/scheduler/IndexAutoSyncScheduler.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -20,6 +21,7 @@ public class IndexAutoSyncScheduler {
   private final IndexSyncService indexSyncService;
   private final IndexDataRepository indexDataRepository;
 
+  @Transactional
   @Scheduled(cron = "${batch.index-sync.cron:0 0 0 * * *}")
   public void syncAllEnabledIndices() {
     log.info("[배치 시작] 자동 연동 설정된 지수 목록 연동");

--- a/src/main/java/com/kueennevercry/findex/service/IndexInfoService.java
+++ b/src/main/java/com/kueennevercry/findex/service/IndexInfoService.java
@@ -1,21 +1,22 @@
 package com.kueennevercry.findex.service;
 
-import com.kueennevercry.findex.dto.request.IndexInfoCreateRequest;
-import com.kueennevercry.findex.dto.response.IndexInfoDto;
-import com.kueennevercry.findex.dto.request.IndexInfoUpdateRequest;
-import com.kueennevercry.findex.dto.request.IndexInfoListRequest;
-import com.kueennevercry.findex.dto.response.CursorPageResponse;
 import com.kueennevercry.findex.dto.IndexInfoSummaryDto;
+import com.kueennevercry.findex.dto.request.IndexInfoCreateRequest;
+import com.kueennevercry.findex.dto.request.IndexInfoListRequest;
+import com.kueennevercry.findex.dto.request.IndexInfoUpdateRequest;
+import com.kueennevercry.findex.dto.response.CursorPageResponse;
+import com.kueennevercry.findex.dto.response.IndexInfoDto;
+import com.kueennevercry.findex.entity.AutoSyncConfig;
 import com.kueennevercry.findex.entity.IndexInfo;
 import com.kueennevercry.findex.mapper.IndexInfoMapper;
-import com.kueennevercry.findex.repository.IndexInfoRepository;
-import com.kueennevercry.findex.repository.IndexDataRepository;
 import com.kueennevercry.findex.repository.AutoSyncConfigRepository;
+import com.kueennevercry.findex.repository.IndexDataRepository;
+import com.kueennevercry.findex.repository.IndexInfoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import jakarta.persistence.EntityNotFoundException;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -37,8 +38,7 @@ public class IndexInfoService {
   }
 
   /**
-   * 전체 지수 정보 요약 목록 조회
-   * ID, 지수명, 지수 분류명만 포함한 간단한 목록을 반환
+   * 전체 지수 정보 요약 목록 조회 ID, 지수명, 지수 분류명만 포함한 간단한 목록을 반환
    */
   public List<IndexInfoSummaryDto> findAllSummaries() {
     List<IndexInfo> indexInfos = indexInfoRepository.findAllByOrderByIdAsc();
@@ -49,17 +49,11 @@ public class IndexInfoService {
 
   /**
    * 커서 기반 페이징으로 지수 정보 목록 조회
-   * 
-   * 커서 기반 페이징의 장점:
-   * 1. 대용량 데이터에서 일관된 성능 (OFFSET 없이 WHERE 조건만 사용)
-   * 2. 실시간 데이터 변경에도 안정적 (중복/누락 방지)
-   * 3. 무한 스크롤 UI에 최적화
-   * 
-   * 동작 과정:
-   * 1. 요청 파라미터 검증 및 기본값 적용
-   * 2. Repository에서 size+1개 데이터 조회
-   * 3. 다음 페이지 존재 여부 판단
-   * 4. 다음 커서 정보 생성
+   * <p>
+   * 커서 기반 페이징의 장점: 1. 대용량 데이터에서 일관된 성능 (OFFSET 없이 WHERE 조건만 사용) 2. 실시간 데이터 변경에도 안정적 (중복/누락 방지) 3.
+   * 무한 스크롤 UI에 최적화
+   * <p>
+   * 동작 과정: 1. 요청 파라미터 검증 및 기본값 적용 2. Repository에서 size+1개 데이터 조회 3. 다음 페이지 존재 여부 판단 4. 다음 커서 정보 생성
    * 5. 응답 DTO 구성
    */
   public CursorPageResponse<IndexInfoDto> findWithCursorPaging(IndexInfoListRequest request) {
@@ -122,12 +116,11 @@ public class IndexInfoService {
 
   /**
    * 다음 페이지를 위한 커서 생성
-   * 
-   * 현재는 단순 ID 기반이지만, 복합 정렬이 필요한 경우
-   * Base64로 인코딩된 복합 커서를 생성할 수 있습니다.
-   * 
-   * 예: {"sortField": "indexName", "sortValue": "IT서비스", "id": 123}
-   * -> Base64 인코딩 -> "eyJzb3J0RmllbGQiOi..."
+   * <p>
+   * 현재는 단순 ID 기반이지만, 복합 정렬이 필요한 경우 Base64로 인코딩된 복합 커서를 생성할 수 있습니다.
+   * <p>
+   * 예: {"sortField": "indexName", "sortValue": "IT서비스", "id": 123} -> Base64 인코딩 ->
+   * "eyJzb3J0RmllbGQiOi..."
    */
   private String generateCursor(IndexInfo lastItem, IndexInfoListRequest request) {
     // 현재는 단순 구현 (ID만 사용)
@@ -157,22 +150,20 @@ public class IndexInfoService {
 
     IndexInfo savedIndexInfo = indexInfoRepository.save(indexInfo);
 
+    // 자동 연동 설정 등록
+    autoSyncConfigRepository.save(new AutoSyncConfig(savedIndexInfo));
+
     return indexInfoMapper.toDto(savedIndexInfo);
   }
 
   /**
    * 지수 정보 수정
-   *
-   * JPA 더티 체킹(Dirty Checking) 활용
-   * - findById()로 조회한 엔티티는 영속성 컨텍스트에서 관리됨
-   * - 엔티티 필드 변경 시 JPA가 자동으로 변경사항을 감지
-   * - @Transactional 메서드 종료 시점에 자동으로 UPDATE 쿼리 실행
-   * - 따라서 repository.save() 호출이 불필요함
-   *
-   * 주의사항:
-   * - @Transactional 어노테이션이 반드시 필요
-   * - findById()로 조회한 영속 상태의 엔티티여야 함
-   * - 변경된 필드만 UPDATE 쿼리에 포함되어 성능상 유리
+   * <p>
+   * JPA 더티 체킹(Dirty Checking) 활용 - findById()로 조회한 엔티티는 영속성 컨텍스트에서 관리됨 - 엔티티 필드 변경 시 JPA가 자동으로
+   * 변경사항을 감지 - @Transactional 메서드 종료 시점에 자동으로 UPDATE 쿼리 실행 - 따라서 repository.save() 호출이 불필요함
+   * <p>
+   * 주의사항: - @Transactional 어노테이션이 반드시 필요 - findById()로 조회한 영속 상태의 엔티티여야 함 - 변경된 필드만 UPDATE 쿼리에 포함되어
+   * 성능상 유리
    */
   @Transactional // 오버라이드: readOnly = false
   public IndexInfoDto update(Long id, IndexInfoUpdateRequest request) {
@@ -202,13 +193,10 @@ public class IndexInfoService {
 
   /**
    * 지수 정보 삭제
-   * 
-   * 삭제 순서:
-   * 1. 지수 정보 존재 여부 확인
-   * 2. 연관된 지수 데이터(IndexData) 삭제
-   * 3. 연관된 자동 연동 설정(AutoSyncConfig) 삭제
-   * 4. 지수 정보(IndexInfo) 삭제
-   * 
+   * <p>
+   * 삭제 순서: 1. 지수 정보 존재 여부 확인 2. 연관된 지수 데이터(IndexData) 삭제 3. 연관된 자동 연동 설정(AutoSyncConfig) 삭제 4. 지수
+   * 정보(IndexInfo) 삭제
+   *
    * @Transactional을 통해 모든 삭제 작업이 원자적으로 실행됨
    */
   @Transactional // 오버라이드: readOnly = false

--- a/src/main/java/com/kueennevercry/findex/service/RealIndexSyncService.java
+++ b/src/main/java/com/kueennevercry/findex/service/RealIndexSyncService.java
@@ -17,6 +17,6 @@ public class RealIndexSyncService implements IndexSyncService {
   @Override
   public void sync(Long indexInfoId, LocalDate from, LocalDate to) {
     IndexDataSyncRequest request = new IndexDataSyncRequest(List.of(indexInfoId), from, to);
-    syncJobService.syncIndexData(request);
+    syncJobService.syncIndexData(request, "SYSTEM");
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,8 +21,7 @@ spring:
 
 batch:
   index-sync:
-    cron: "0 * * * * *"
-#    cron: "0 0 0 * * *"
+    cron: "0 0 0 * * *"
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,7 +21,8 @@ spring:
 
 batch:
   index-sync:
-    cron: "0 0 0 * * *"
+    cron: "0 * * * * *"
+#    cron: "0 0 0 * * *"
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## 📝 변경사항 요약
- 자동 연동 지수 목록 조회 시 지수 정보 표시되지 않던 버그 수정
- Open API 연동 시 자동 연동 설정(AutoSyncConfig) 누락되던 문제 해결
- 배치 스케줄러에서 LazyInitializationException 발생하던 문제 해결

## 📋 체크리스트
- [x] OpenAPI 연동 시 신규 지수에 대해 AutoSyncConfig 자동 생성
- [x] 이미 존재하는 지수에 대해서는 중복 생성 방지
- [x] 배치 스케줄러에서 지수명 접근 시 Fetch 오류 수정 (join fetch 적용)
- [x] 연동 후 목록에 반영되는지 통합 테스트 수행

## 🔗 관련 이슈
closes #91 

## 💬 추가 설명
- SyncJobService 내 saveIndexInfo() 및 updateIndexInfo() 로직에 자동 연동 설정 생성 처리 추가
- AutoSyncConfigRepository에 existsByIndexInfo_Id() 메서드 활용해 중복 저장 방지
- 배치 스케줄러에서 Lazy 로딩된 IndexInfo 접근 시 오류 발생 → @Transactional 추가로 해결